### PR TITLE
Revamp APK Set parsing

### DIFF
--- a/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/AndroidManifest.kt
+++ b/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/AndroidManifest.kt
@@ -83,5 +83,10 @@ public class UsesPermission private constructor(
 
 public class UsesSdk private constructor(
     public val minSdkVersion: Int = 1,
-    public val targetSdkVersion: Int?,
-)
+    public val targetSdkVersion: Int?
+) {
+    override fun equals(other: Any?): Boolean = other is UsesSdk &&
+            minSdkVersion == other.minSdkVersion && targetSdkVersion == other.targetSdkVersion
+
+    override fun hashCode(): Int = 31 * minSdkVersion.hashCode() + targetSdkVersion.hashCode()
+}

--- a/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/ApkSet.kt
+++ b/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/ApkSet.kt
@@ -246,7 +246,7 @@ public class ApkSet private constructor(
 
                         // There can only be one base apk description in a variant.
                         if (baseSplit != null) {
-                            return ParseApkSetResult.Error.MultipleBaseApkDescriptionsError
+                            return ParseApkSetResult.Error.DuplicateBaseSplitsError
                         }
 
                         // A base APK file should have a null split instead of an empty one, search for such.
@@ -601,6 +601,10 @@ public sealed class ParseApkSetResult {
          */
         public object BaseApkDescriptionInconsistentError : Error() {
             override val message: String = "base apk description is not consistent with itself"
+        }
+
+        public object DuplicateBaseSplitsError : Error() {
+            override val message: String = "duplicate base apk descriptions found"
         }
 
         /**

--- a/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/ApkSet.kt
+++ b/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/ApkSet.kt
@@ -1,26 +1,26 @@
 package app.accrescent.parcelo.apksparser
 
+import com.android.bundle.Commands
 import com.android.bundle.Commands.BuildApksResult
+import com.android.bundle.Targeting
+import com.android.bundle.Targeting.Abi.AbiAlias
 import com.github.zafarkhaja.semver.ParseException
 import com.github.zafarkhaja.semver.Version
 import com.google.protobuf.InvalidProtocolBufferException
 import java.io.InputStream
 import java.security.MessageDigest
 import java.security.cert.X509Certificate
-import java.util.Optional
 import java.util.zip.ZipInputStream
 
 public class ApkSet private constructor(
-    public val appId: AppId,
+    public val appId: String,
     public val versionCode: Int,
     public val versionName: String,
+    public val minSdk: Int,
     public val targetSdk: Int,
     public val bundletoolVersion: Version,
     public val reviewIssues: List<String>,
-    public val abiSplits: Set<String>,
-    public val densitySplits: Set<String>,
-    public val langSplits: Set<String>,
-    public val entrySplitNames: Map<String, Optional<String>>,
+    public val variants: Set<Variant>
 ) {
     public companion object {
         /**
@@ -33,30 +33,32 @@ public class ApkSet private constructor(
          *
          * - the input file is a valid ZIP
          * - all non-directory entries in said ZIP except for "toc.pb" are valid APKs
-         * - "toc.pb" is a valid BuildApksResult protocol buffer
+         * - "toc.pb" is a valid BuildApksResult protocol buffer (referred to as the metadata)
          * - the input ZIP contains at least one APK
          * - all APKs must not be debuggable
          * - all APKs must not be marked test only
          * - all APKs have the same signing certificates
          * - all APKs have the same app ID and version code
          * - all APKs have unique split names
-         * - exactly one APK is a base APK (i.e., has an empty split name)
-         * - the base APK specifies a version name
+         * - the metadata is not marked as in testing mode
+         * - the metadata specifies at least one variant (group of APKs)
+         * - the metadata does not use any targeting functionality outside SDK for variants, and conventional
+         * abi/lang/density for APKs.
+         * - the metadata does not use any module functionality
+         * - the metadata only uses non-instant split APKs
+         * - there are no duplicate variants, apks, splits, etc.
+         * - each apk specified has a valid corresponding APK file of the same split id in the apk set
+         * - each variant has a base APK
+         * - the base APKs and metadata collectively specify consistent application ids, version codes, version names,
+         * sdk versions, etc.
          *
          * @return metadata describing the APK set and the app it represents
          */
         public fun parse(file: InputStream): ParseApkSetResult {
-            var appId: AppId? = null
-            var versionCode: Int? = null
-            var versionName: String? = null
-            var targetSdk: Int? = null
-            var bundletoolVersion: Version? = null
+            data class ApkEntry(val innerApk: Apk, val path: String)
 
-            data class Split(val name: String?, val variantNumber: Int?)
-            val reviewIssues = mutableListOf<String>()
-            val variantMap = mutableMapOf<String, Int>()
-            val splits = mutableSetOf<Split>()
-            val entrySplitNames = mutableMapOf<String, Optional<String>>()
+            var bundletoolMetadata: BuildApksResult? = null
+            val apkEntries = mutableListOf<ApkEntry>()
 
             ZipInputStream(file).use { zip ->
                 var pinnedCertHashes = emptyList<String>()
@@ -64,34 +66,17 @@ public class ApkSet private constructor(
                 generateSequence { zip.nextEntry }.filterNot { it.isDirectory }.forEach { entry ->
                     val entryBytes = zip.readBytes()
 
-                    // Parse metadata
                     if (entry.name == "toc.pb") {
-                        val bundletoolMetadata = try {
+                        bundletoolMetadata = try {
                             BuildApksResult.newBuilder().mergeFrom(entryBytes).build()
                         } catch (e: InvalidProtocolBufferException) {
-                            return ParseApkSetResult.Error.BundletoolMetadataError
+                            return ParseApkSetResult.Error.MetadataParseError
                         }
-                        // Validate bundletool version
-                        bundletoolVersion = try {
-                            Version.Builder(bundletoolMetadata.bundletool.version).build()
-                        } catch (e: ParseException) {
-                            return ParseApkSetResult.Error.BundletoolVersionError
-                        }
-                        bundletoolMetadata.variantList.forEach { variant ->
-                            variant.apkSetList.forEach { apkSet ->
-                                apkSet.apkDescriptionList.forEach {
-                                    variantMap[it.path] = variant.variantNumber
-                                }
-                            }
-                        }
-                        return@forEach
                     }
 
                     val apk = when (val result = Apk.parse(entryBytes)) {
                         is ParseApkResult.Ok -> result.apk
-                        is ParseApkResult.Error -> return ParseApkSetResult.Error.ApkParseError(
-                            result
-                        )
+                        is ParseApkResult.Error -> return ParseApkSetResult.Error.ApkParseError(result)
                     }
 
                     // Pin the APK signing certificates on the first APK encountered to ensure split APKs
@@ -106,118 +91,339 @@ public class ApkSet private constructor(
                         }
                     }
 
-                    if (!splits.add(Split(apk.manifest.split, variantMap[entry.name]))) {
-                        return ParseApkSetResult.Error.DuplicateSplitError
-                    }
-
+                    // Fail on debuggable and testing APKs which have naturally weaker signatures
                     if (apk.manifest.application.debuggable == true) {
                         return ParseApkSetResult.Error.DebuggableError
                     }
+
                     if (apk.manifest.application.testOnly == true) {
                         return ParseApkSetResult.Error.TestOnlyError
                     }
 
-                    // Pin common data on the first manifest parsed to ensure all split APKs have
-                    // the same app ID and version code.
-                    if (appId == null) {
-                        appId = apk.manifest.`package`
-                        versionCode = apk.manifest.versionCode
-                    } else {
-                        // Check that the app ID and version code are the same as previously pinned
-                        if (
-                            apk.manifest.`package` != appId ||
-                            apk.manifest.versionCode != versionCode
+                    // Check that the app ID and version code are the same as previously pinned
+                    apkEntries.lastOrNull()?.run {
+                        if (innerApk.manifest.`package` != apk.manifest.`package` ||
+                            innerApk.manifest.versionCode != apk.manifest.versionCode
                         ) {
                             return ParseApkSetResult.Error.ManifestInfoInconsistentError
                         }
                     }
+                }
+            }
 
-                    // Update the review issues, version name, and target SDK if this is the base APK
-                    if (apk.manifest.split == null) {
-                        // Permissions
-                        apk.manifest.usesPermissions?.let { permissions ->
-                            reviewIssues.addAll(permissions.map { it.name })
+            // Make sure that we successfully found some metadata and a non-zero amount of entries
+            val metadata = bundletoolMetadata ?: return ParseApkSetResult.Error.MetadataNotFoundError
+            if (apkEntries.isEmpty()) return ParseApkSetResult.Error.ApksNotFoundError
+
+            val bundletoolVersion = try {
+                Version.Builder(metadata.bundletool.version).build()
+            } catch (e: ParseException) {
+                return ParseApkSetResult.Error.BundletoolVersionError
+            }
+
+            // It's somewhat unclear, but this flag is also likely related to testing and should be treated as such.
+            if (metadata.localTestingInfo.enabled) {
+                return ParseApkSetResult.Error.TestOnlyError
+            }
+
+            // Check for unsupported base-level metadata features.
+            if (metadata.assetSliceSetList.isNotEmpty() ||
+                metadata.assetModulesInfo != null ||
+                metadata.defaultTargetingValueList.isNotEmpty() ||
+                metadata.permanentlyFusedModulesList.isNotEmpty()
+            ) {
+                return ParseApkSetResult.Error.MetadataUnsupportedError
+            }
+
+            // If we don't have any variants, we don't have any APKs.
+            if (metadata.variantList.isEmpty()) {
+                return ParseApkSetResult.Error.VariantsNotFoundError
+            }
+
+            // Track variants alongside their SDK numbers and numberings to mitigate duplicate entries
+            val variants = mutableSetOf<Variant>()
+            val variantSdks = mutableSetOf<Int>()
+            val variantNumbering = mutableSetOf<Int>()
+
+            // We will be encountering base splits as we parse variants, so start tracking the information
+            // we need from them. Since there can be multiple, we want to make sure we are tracking "aggregate"
+            // information, so we can check for inconsistency later.
+            val appIds = mutableSetOf<String>()
+            val versionCodes = mutableSetOf<Int>()
+            val versionNames = mutableSetOf<String?>()
+            val usesSdks = mutableSetOf<UsesSdk?>()
+            val reviewIssueSets = mutableSetOf<List<String>>()
+
+            val consumed = mutableSetOf<ApkEntry>()
+
+            for (variant in metadata.variantList) {
+                val variantTargeting = variant.targeting
+
+                // Currently we only accept variant targeting by SDK, as that is the only reasonable way
+                // the base splits (which usually have version-dependent compression) can be propertly tracked.
+                if (variantTargeting.abiTargeting != null ||
+                    variantTargeting.screenDensityTargeting != null ||
+                    variantTargeting.multiAbiTargeting != null ||
+                    variantTargeting.textureCompressionFormatTargeting != null ||
+                    variantTargeting.sdkRuntimeTargeting != null
+                ) {
+                    return ParseApkSetResult.Error.VariantTargetingUnsupportedError
+                }
+
+                // Since we've ruled out all other targets as being null, if this field is missing too, that means
+                // that the variant has no target information usable by the device, which is probably invalid.
+                val sdkTargeting = variant.targeting.sdkVersionTargeting
+                    ?: return ParseApkSetResult.Error.VariantTargetsNothingError
+                // Only accept a single SDK value for now. You will see this in a few other places as it's currently
+                // unclear why or how these fields would have more than one value.
+                val sdk = sdkTargeting.valueList.singleOrNull()
+                    ?: return ParseApkSetResult.Error.VariantSDKUnsupportedError
+                val minSdk = sdk.min.value
+
+                // Mitigate duplicate variants
+                if (!variantSdks.add(minSdk) || !variantNumbering.add(variant.variantNumber)) {
+                    return ParseApkSetResult.Error.DuplicateVariantError
+                }
+
+                val apkSet = variant.apkSetList.singleOrNull() ?:
+                    return ParseApkSetResult.Error.ApkSetUnsupportedError
+
+                // We currently don't support non-base feature modules. Error out if any other modules are encountered
+                // to avoid putting invalid APKs into the repository.
+                val module = apkSet.moduleMetadata
+                if (module.name != "base" || module.moduleType != Commands.FeatureModuleType.FEATURE_MODULE ||
+                    module.isInstant || module.dependenciesList.isNotEmpty() ||
+                    module.runtimeEnabledSdkDependenciesList.isNotEmpty()
+                ) {
+                    return ParseApkSetResult.Error.ModuleUnsupportedError
+                }
+
+                // Base feature modules have no targeting, so targeted modules are also considered a sign of several
+                // feature modules and considered invalid.
+                val moduleTargeting = apkSet.moduleMetadata.targeting
+                if (moduleTargeting.sdkVersionTargeting != null || moduleTargeting.deviceFeatureTargetingList.isNotEmpty() ||
+                    moduleTargeting.userCountriesTargeting != null || moduleTargeting.deviceGroupTargeting != null
+                ) {
+                    return ParseApkSetResult.Error.ModuleTargetingUnsupportedError
+                }
+
+                // There should only be one base split, and then an arbitrary amount of splits for ABI, language, and
+                // density. Note that splits in several variants could point to the same APK file.
+                // TODO: Disallow two splits in one variant pointing to the same APK file
+                var baseSplit: String? = null
+                val abiSplits = mutableMapOf<String, String>()
+                val langSplits = mutableMapOf<String, String>()
+                val densitySplits = mutableMapOf<String, String>()
+                for (apkDescription in apkSet.apkDescriptionList) {
+                    // Disallow any non-split (i.e. instant, APEX) APKs. Also disallow any rotated keys for now
+                    // until it's clear what they do. TODO: See prior
+                    if (apkDescription.splitApkMetadata == null ||
+                        !apkDescription.signingDescription.signedWithRotatedKey
+                    ) {
+                        return ParseApkSetResult.Error.ApkDescriptionUnsupportedError
+                    }
+
+                    val path = apkDescription.path
+                    val splitId = apkDescription.splitApkMetadata.splitId
+                    val isBase = apkDescription.splitApkMetadata.isMasterSplit
+                    if (isBase || splitId.isEmpty()) {
+                        // Base APKs should have the corresponding metadata flag set and an empty ID. Any other
+                        // configuration should be invalid.
+                        if (!isBase || splitId.isNotEmpty()) {
+                            return ParseApkSetResult.Error.BaseApkDescriptionInconsistentError
                         }
 
-                        // Service intent filter actions
-                        apk.manifest.application.services?.let { services ->
+                        // There can only be one base apk description in a variant.
+                        if (baseSplit != null) {
+                            return ParseApkSetResult.Error.MultipleBaseApkDescriptionsError
+                        }
+
+                        // A base APK file should have a null split instead of an empty one, search for such.
+                        val apkEntry = apkEntries.filter { it.path == path && it.innerApk.manifest.split == null }
+                            .ifEmpty { return ParseApkSetResult.Error.NoBaseSplitsFoundError }
+                            .singleOrNull() ?: return ParseApkSetResult.Error.MultipleBaseSplitsFoundError
+
+                        baseSplit = apkEntry.path
+
+                        // Aggregate the apk's manifest values
+                        val manifest = apkEntry.innerApk.manifest
+                        appIds.add(manifest.`package`.value)
+                        versionCodes.add(manifest.versionCode)
+                        versionNames.add(manifest.versionName)
+                        usesSdks.add(manifest.usesSdk)
+
+                        // Aggregate any permissions/service values that may need to be reviewed
+                        val issues = mutableListOf<String>()
+                        manifest.usesPermissions?.let { permissions ->
+                            permissions.mapTo(issues) { it.name }
+                        }
+                        manifest.application.services?.let { services ->
                             services
-                                .flatMap { it.intentFilters.orEmpty() }
-                                .flatMap { it.actions }
-                                .map { it.name }
-                                .forEach { reviewIssues.add(it) }
+                                .flatMap { service -> service.intentFilters.orEmpty().flatMap { it.actions } }
+                                .mapTo(issues) { it.name }
+                        }
+                        reviewIssueSets.add(issues)
+
+                        consumed.add(apkEntry)
+                    } else {
+                        // These APK targets are not supported by the client and should be disallowed for now.
+                        val apkTargeting = apkDescription.targeting
+                        if (apkTargeting.textureCompressionFormatTargeting != null ||
+                            apkTargeting.multiAbiTargeting != null ||
+                            apkTargeting.sanitizerTargeting != null ||
+                            apkTargeting.deviceTierTargeting != null ||
+                            apkTargeting.countrySetTargeting != null
+                        ) {
+                            return ParseApkSetResult.Error.ApkTargetingUnsupportedError
                         }
 
-                        // Version name
-                        apk.manifest.versionName
-                            ?.let { versionName = it }
-                            ?: return ParseApkSetResult.Error.BaseApkVersionNameUnspecifiedError
+                        // We only allow an APK to target either abi, language, or density, currently. Combinations
+                        // are disallowed.
+                        val abiTargeting = apkTargeting.abiTargeting
+                        val langTargeting = apkTargeting.languageTargeting
+                        val densityTargeting = apkTargeting.screenDensityTargeting
 
-                        // Target SDK
-                        apk.manifest.usesSdk
-                            ?.let { targetSdk = it.targetSdkVersion ?: it.minSdkVersion }
-                            ?: return ParseApkSetResult.Error.BaseApkTargetSdkUnspecifiedError
-                    }
+                        val (id, dst) = when {
+                            abiTargeting != null -> {
+                                if (langTargeting != null || densityTargeting != null) {
+                                    return ParseApkSetResult.Error.ApkTargetingUnsupportedError
+                                }
 
-                    // Update the entry name -> split mapping
-                    entrySplitNames[entry.name] = apk.manifest.split
-                        ?.let { Optional.of(it.substringAfter("config.")) }
-                        ?: Optional.empty()
-                }
-            }
+                                // Transform the ABI alias into a string value usable with the repodata format
+                                val abi = abiTargeting.valueList.singleOrNull()
+                                    ?: return ParseApkSetResult.Error.ApkSetUnsupportedError
+                                val name = when (abi.alias) {
+                                    AbiAlias.ARMEABI_V7A -> "armeabi_v7a"
+                                    AbiAlias.ARM64_V8A -> "arm64_v8a"
+                                    AbiAlias.X86 -> "x86"
+                                    AbiAlias.X86_64 -> "x86_64"
+                                    else -> return ParseApkSetResult.Error.AbiUnsupportedError
+                                }
+                                Pair(name, abiSplits)
+                            }
 
-            // Update metadata with split config names
-            val (abiSplits, langSplits, densitySplits) = run {
-                val abiSplits = mutableSetOf<String>()
-                val langSplits = mutableSetOf<String>()
-                val densitySplits = mutableSetOf<String>()
+                            // Due to when condition logic, we actually don't need to fully check that the other
+                            // two values are null since they were already ruled out by prior when blocks.
 
-                for (split in splits) {
-                    split.name?.let {
-                        try {
-                            when (getSplitTypeForName(it)) {
-                                SplitType.ABI -> abiSplits
-                                SplitType.LANGUAGE -> langSplits
-                                SplitType.SCREEN_DENSITY -> densitySplits
-                            }.add(it.substringAfter("config."))
-                        } catch (e: SplitNameNotConfigException) {
-                            return ParseApkSetResult.Error.InvalidSplitNameError(it)
+                            langTargeting != null -> {
+                                if (densityTargeting != null) {
+                                    return ParseApkSetResult.Error.ApkTargetingUnsupportedError
+                                }
+
+                                val lang = langTargeting.valueList.singleOrNull()
+                                    ?: return ParseApkSetResult.Error.LangUnsupportedError
+                                Pair(lang, langSplits)
+                            }
+
+                            densityTargeting != null -> {
+                                // Transform the ABI alias into a string value usable with the repodata format
+                                val density = densityTargeting.valueList.singleOrNull()
+                                    ?: return ParseApkSetResult.Error.ApkSetUnsupportedError
+                                val name = when (density.densityAlias) {
+                                    Targeting.ScreenDensity.DensityAlias.NODPI -> "nodpi"
+                                    Targeting.ScreenDensity.DensityAlias.LDPI -> "ldpi"
+                                    Targeting.ScreenDensity.DensityAlias.MDPI -> "mdpi"
+                                    Targeting.ScreenDensity.DensityAlias.TVDPI -> "tvdpi"
+                                    Targeting.ScreenDensity.DensityAlias.HDPI -> "hdpi"
+                                    Targeting.ScreenDensity.DensityAlias.XHDPI -> "xhdpi"
+                                    Targeting.ScreenDensity.DensityAlias.XXHDPI -> "xxhdpi"
+                                    Targeting.ScreenDensity.DensityAlias.XXXHDPI -> "xxxhdpi"
+                                    else -> return ParseApkSetResult.Error.DensityUnsupportedError
+                                }
+                                Pair(name, densitySplits)
+                            }
+
+                            // Since we've already ruled out all other APK targets, this implies that the APK
+                            // targets no device attribute, which is probably invalid.
+                            else -> return ParseApkSetResult.Error.ApkTargetsNothingError
                         }
+
+                        // Avoid duplicate apk descriptions with the same targeting
+                        if (dst[id] != null) {
+                            return ParseApkSetResult.Error.MultipleApkDescriptionsError
+                        }
+
+                        // In manifests and in the split metadata, all the target parameters used are prefixed
+                        // with "config". Keep this in mind when validating the target and
+                        val targetSplitId = "config.${id}"
+                        if (splitId != targetSplitId) {
+                            return ParseApkSetResult.Error.SplitIdInconsistentError
+                        }
+
+                        val apkEntry =
+                            apkEntries.filter { it.path == path && it.innerApk.manifest.split == targetSplitId }
+                                .ifEmpty { return ParseApkSetResult.Error.NoSplitsFoundError }
+                                .singleOrNull() ?: return ParseApkSetResult.Error.MultipleSplitsFoundError
+                        dst[id] = apkEntry.path
+                        consumed.add(apkEntry)
                     }
                 }
-
-                Triple(abiSplits.toSet(), langSplits.toSet(), densitySplits.toSet())
+                val newVariant = Variant(
+                    minSdk,
+                    baseSplit ?: return ParseApkSetResult.Error.BaseApkNotFoundError,
+                    abiSplits,
+                    langSplits,
+                    densitySplits
+                )
+                variants.add(newVariant)
             }
 
-            // If there isn't a base APK, freak out
-            if (splits.none { it.name == null }) {
-                return ParseApkSetResult.Error.BaseApkNotFoundError
+            // It's possible that the metadata might have been tampered with in order to not list certain APKs.
+            // In this case, we must make sure that all the Apks linked during variant parsing encompass
+            // all the variants discovered during the initial parsing phase.
+            if (consumed.size != apkEntries.size) {
+                return ParseApkSetResult.Error.UnaccountedSplitsError
             }
 
-            when {
-                appId == null || versionCode == null -> return ParseApkSetResult.Error.ApksNotFoundError
-                versionName == null -> return ParseApkSetResult.Error.VersionNameNotFoundError
-                targetSdk == null -> return ParseApkSetResult.Error.TargetSdkNotFoundError
-                bundletoolVersion == null -> return ParseApkSetResult.Error.BundletoolVersionNotFoundError
+            // Start combining the values discovered from each base APK into a single value (barring disagreements)
+            val appId = appIds.singleOrNull() ?: return ParseApkSetResult.Error.AppIdInconsistentError
+            if (metadata.packageName != appId) {
+                return ParseApkSetResult.Error.AppIdInconsistentError
             }
+
+            val versionCode = versionCodes.singleOrNull() ?: return ParseApkSetResult.Error.VersionCodeInconsistentError
+
+            // versionName (and later usesSdk) are already nullable, so using singleOrNull would not allow us to handle
+            // all possibilities. Replicate the functionality manually instead and return two different errors for
+            // each type of "null" encountered.
+            val versionName = if (versionNames.size == 1) {
+                versionNames.first() ?: return ParseApkSetResult.Error.VersionNameUnspecifiedError
+            } else {
+                return ParseApkSetResult.Error.VersionNameInconsistentError
+            }
+
+            val usesSdk = if (usesSdks.size == 1) {
+                usesSdks.first() ?: return ParseApkSetResult.Error.SdkUnspecifiedError
+            } else {
+                return ParseApkSetResult.Error.SdkInconsistentError
+            }
+            val minSdk = usesSdk.minSdkVersion
+            val targetSdk = usesSdk.targetSdkVersion ?: return ParseApkSetResult.Error.TargetSdkUnspecifiedError
+            val reviewIssues = reviewIssueSets.singleOrNull() ?:
+                return ParseApkSetResult.Error.ReviewIssueInconsistentError
 
             val apkSet = ApkSet(
-                appId!!,
-                versionCode!!,
-                versionName!!,
-                targetSdk!!,
-                bundletoolVersion!!,
+                appId,
+                versionCode,
+                versionName,
+                minSdk,
+                targetSdk,
+                bundletoolVersion,
                 reviewIssues,
-                abiSplits,
-                densitySplits,
-                langSplits,
-                entrySplitNames,
+                variants
             )
 
             return ParseApkSetResult.Ok(apkSet)
         }
     }
 }
+public class Variant(
+    public val minSdk: Int,
+    public val baseSplit: String,
+    public val abiSplits: Map<String, String>,
+    public val langSplits: Map<String, String>,
+    public val densitySplits: Map<String, String>
+)
 
 /**
  * Representation of the result of attempting to parse an APK set
@@ -238,6 +444,13 @@ public sealed class ParseApkSetResult {
         public abstract val message: String
 
         /**
+         * An error was encountered in parsing the bundletool metadata
+         */
+        public object MetadataParseError : Error() {
+            override val message: String = "bundletool metadata not valid"
+        }
+
+        /**
          * An error was encountered in parsing an APK
          */
         public data class ApkParseError(val error: ParseApkResult.Error) : Error() {
@@ -245,31 +458,10 @@ public sealed class ParseApkSetResult {
         }
 
         /**
-         * An error was encountered in parsing the bundletool metadata
-         */
-        public object BundletoolMetadataError : Error() {
-            override val message: String = "bundletool metadata not valid"
-        }
-
-        /**
-         * An error was encountered in parsing the bundletool version
-         */
-        public object BundletoolVersionError : Error() {
-            override val message: String = "invalid bundletool version"
-        }
-
-        /**
          * A mismatch exists between APK signing certificates
          */
         public object SigningCertMismatchError : Error() {
             override val message: String = "APK signing certificates don't match each other"
-        }
-
-        /**
-         * A duplicate split APK name was detected
-         */
-        public object DuplicateSplitError : Error() {
-            override val message: String = "duplicate split names found"
         }
 
         /**
@@ -294,24 +486,10 @@ public sealed class ParseApkSetResult {
         }
 
         /**
-         * The base APK doesn't specify a version name
+         * The apk set metadata (toc.pb) was not found
          */
-        public object BaseApkVersionNameUnspecifiedError : Error() {
-            override val message: String = "base APK doesn't specify a version name"
-        }
-
-        /**
-         * The base APK doesn't specify a target SDK
-         */
-        public object BaseApkTargetSdkUnspecifiedError : Error() {
-            override val message: String = "base APK doesn't specify a target SDK"
-        }
-
-        /**
-         * No base APK was found
-         */
-        public object BaseApkNotFoundError : Error() {
-            override val message: String = "no base APK found"
+        public object MetadataNotFoundError : Error() {
+            override val message: String = "metadata was not found"
         }
 
         /**
@@ -322,31 +500,246 @@ public sealed class ParseApkSetResult {
         }
 
         /**
-         * No version name was found in the APK set
+         * An error was encountered in parsing the bundletool version
          */
-        public object VersionNameNotFoundError : Error() {
-            override val message: String = "no version name specified"
+        public object BundletoolVersionError : Error() {
+            override val message: String = "invalid bundletool version"
         }
 
         /**
-         * No target SDK was found in the APK set
+         * The apk set metadata used features not supported by accrescent
          */
-        public object TargetSdkNotFoundError : Error() {
-            override val message: String = "no targetSdk specified"
+        public object MetadataUnsupportedError : Error() {
+            override val message: String = "metadata uses unsupported features"
         }
 
         /**
-         * No bundletool version was found in the APK set
+         * No variants (and thus no apks) were found in the apk set metadata
          */
-        public object BundletoolVersionNotFoundError : Error() {
-            override val message: String = "no bundletool version found"
+        public object VariantsNotFoundError : Error() {
+            override val message: String = "no variants were found"
         }
 
         /**
-         * Parsing encountered an invalid configuration split APK name
+         * The variant targeting used parameters not supported by accrescent
          */
-        public data class InvalidSplitNameError(val splitName: String) : Error() {
-            override val message: String = "$splitName is not a valid configuration split name"
+        public object VariantTargetingUnsupportedError : Error() {
+            override val message: String = "variant uses unsupported targeting"
+        }
+
+        /**
+         * A variant targeted no usable device attribute.
+         */
+        public object VariantTargetsNothingError : Error() {
+            override val message: String = "variant targets no device attribute"
+        }
+
+        /**
+         * The variant SDK targeting used a format unsupported by accrescent
+         */
+        public object VariantSDKUnsupportedError : Error() {
+            override val message: String = "variant uses unsupported sdk targeting"
+        }
+
+        /**
+         * Two variants were with the same number and/or minimum SDK were discovered
+         */
+        public object DuplicateVariantError : Error() {
+            override val message: String = "duplicate variants found"
+        }
+
+        /**
+         * The apk set used features unsupported by accrescent
+         */
+        public object ApkSetUnsupportedError : Error() {
+            override val message: String = "apk set uses unsupported features"
+        }
+
+        /**
+         * The apk set module used features unsupported by accrescent
+         * (i.e. it was not using the default configuration)
+         */
+        public object ModuleUnsupportedError : Error() {
+            override val message: String = "apk set uses unsupported module features"
+        }
+
+        /**
+         * The apk set module targeting used parameters unsupported by accrescent
+         * (i.e. it was not using the default configuration)
+         */
+        public object ModuleTargetingUnsupportedError : Error() {
+            override val message: String = "apk set uses unsupported module targeting"
+        }
+
+        /**
+         * The apk description used features unsupported by accrescent
+         */
+        public object ApkDescriptionUnsupportedError : Error() {
+            override val message: String = "apk description uses unsupported features"
+        }
+
+        /**
+         * A base APK description had a split ID that was inconsistent with it's split APK properties
+         */
+        public object BaseApkDescriptionInconsistentError : Error() {
+            override val message: String = "base apk description is not consistent with itself"
+        }
+
+        /**
+         * Multiple base apk descriptions were encountered in a single variant
+         */
+        public object MultipleBaseApkDescriptionsError : Error() {
+            override val message: String = "multiple base apk descriptions found"
+        }
+
+        /**
+         * No base splits were found for the given apk description's path and split ID
+         */
+        public object NoBaseSplitsFoundError : Error() {
+            override val message: String = "no base splits found for apk description"
+        }
+
+        /**
+         * Several base splits were found for the given apk description's path and split ID
+         */
+        public object MultipleBaseSplitsFoundError : Error() {
+            override val message: String = "multiple base splits found for apk description"
+        }
+
+
+        /**
+         * The apk description's targeting used parameters unsupported by accrescent
+         */
+        public object ApkTargetingUnsupportedError : Error() {
+            override val message: String = "apk description uses unsupported targeting"
+        }
+
+        /**
+         * The apk ABI targeting used a format unsupported by accrescent
+         */
+        public object AbiUnsupportedError : Error() {
+            override val message: String = "apk targeting uses unsupported abi"
+        }
+
+        /**
+         * The apk language targeting used a format unsupported by accrescent
+         */
+        public object LangUnsupportedError : Error() {
+            override val message: String = "apk targeting uses unsupported language"
+        }
+
+        /**
+         * The apk density targeting used a format unsupported by accrescent
+         */
+        public object DensityUnsupportedError : Error() {
+            override val message: String = "apk targeting uses unsupported density"
+        }
+
+        /**
+         * The apk did not target any usable device attribute.
+         */
+        public object ApkTargetsNothingError : Error() {
+            override val message: String = "apk targets no device attribute"
+        }
+
+        /**
+         * Multiple apk descriptions of the same targeting were encountered in a single variant
+         */
+        public object MultipleApkDescriptionsError : Error() {
+            override val message: String = "multiple apk descriptions found"
+        }
+
+        /**
+         * The split ID was inconsistent between the apk description and the split apk's manifest
+         */
+        public object SplitIdInconsistentError : Error() {
+            override val message: String = "apk description and apk manifest do not have the same split ids"
+        }
+
+        /**
+         * No splits were found for the given apk description's path and split ID
+         */
+        public object NoSplitsFoundError : Error() {
+            override val message: String = "no splits found for apk description"
+        }
+
+        /**
+         * Multiple splits were found for the given apk descriptions path and split ID
+         */
+        public object MultipleSplitsFoundError : Error() {
+            override val message: String = "multiple splits found for apk description"
+        }
+
+        /**
+         * No base APK was found for a variant
+         */
+        public object BaseApkNotFoundError : Error() {
+            override val message: String = "no base APK found for variant"
+        }
+
+        /**
+         * There were some splits in the apk set that were not accounted for by the split metadata
+         */
+        public object UnaccountedSplitsError : Error() {
+            override val message: String = "one or more splits unaccounted by metadata"
+        }
+
+        /**
+         * The app id was inconsistent between inside the base splits of each variant, or it was inconsistent between
+         * the base splits and metadata
+         */
+        public object AppIdInconsistentError : Error() {
+            override val message: String = "app id is not the same between base splits and metadata"
+        }
+
+        /**
+         * The version code was inconsistent between the base splits of each variant
+         */
+        public object VersionCodeInconsistentError : Error() {
+            override val message: String = "version code is not the same between base splits"
+        }
+
+        /**
+         * The version name was not specified in any of the base splits of each variant
+         */
+        public object VersionNameUnspecifiedError : Error() {
+            override val message: String = "base splits don't specify a version name"
+        }
+
+        /**
+         * The version name was inconsistent between the base splits of each variant
+         */
+        public object VersionNameInconsistentError : Error() {
+            override val message: String = "version name is not the same between base splits"
+        }
+
+        /**
+         * The sdk version (including min and target sdk) was not specified in any of the base splits
+         * of each variant
+         */
+        public object SdkUnspecifiedError : Error() {
+            override val message: String = "base splits don't specify a sdk"
+        }
+
+        /**
+         * The sdk version (including min and target sdk) was inconsistent between the base splits of each variant
+         */
+        public object SdkInconsistentError : Error() {
+            override val message: String = "sdk is not the same between splits"
+        }
+
+        /**
+         * The target sdk version was not specified in any of the base splits of each variant
+         */
+        public object TargetSdkUnspecifiedError : Error() {
+            override val message: String = "base splits don't specify a target SDK"
+        }
+
+        /**
+         * The review issues were inconsistent between the base splits of each variant
+         */
+        public object ReviewIssueInconsistentError : Error() {
+            override val message: String = "review issues are not the same between base splits"
         }
     }
 }
@@ -360,32 +753,3 @@ private fun X509Certificate.fingerprint(): String {
         .digest(this.encoded)
         .joinToString("") { "%02x".format(it) }
 }
-
-public enum class SplitType { ABI, LANGUAGE, SCREEN_DENSITY }
-
-private val abiSplitNames = setOf("arm64_v8a", "armeabi_v7a", "x86", "x86_64")
-private val densitySplitNames =
-    setOf("ldpi", "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi", "nodpi", "tvdpi")
-
-/**
- * Detects the configuration split API type based on its name
- *
- * @throws SplitNameNotConfigException the split name is not a valid configuration split name
- */
-private fun getSplitTypeForName(splitName: String): SplitType {
-    val configName = splitName.substringAfter("config.")
-    if (configName == splitName) {
-        throw SplitNameNotConfigException(splitName)
-    }
-
-    return if (abiSplitNames.contains(configName)) {
-        SplitType.ABI
-    } else if (densitySplitNames.contains(configName)) {
-        SplitType.SCREEN_DENSITY
-    } else {
-        SplitType.LANGUAGE
-    }
-}
-
-private class SplitNameNotConfigException(splitName: String) :
-    Exception("split name $splitName is not a config split name")

--- a/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/ApkSet.kt
+++ b/apksparser/src/main/kotlin/app/accrescent/parcelo/apksparser/ApkSet.kt
@@ -13,7 +13,7 @@ import java.security.cert.X509Certificate
 import java.util.zip.ZipInputStream
 
 public class ApkSet private constructor(
-    public val appId: String,
+    public val appId: AppId,
     public val versionCode: Int,
     public val versionName: String,
     public val minSdk: Int,
@@ -148,7 +148,7 @@ public class ApkSet private constructor(
             // We will be encountering base splits as we parse variants, so start tracking the information
             // we need from them. Since there can be multiple, we want to make sure we are tracking "aggregate"
             // information, so we can check for inconsistency later.
-            val appIds = mutableSetOf<String>()
+            val appIds = mutableSetOf<AppId>()
             val versionCodes = mutableSetOf<Int>()
             val versionNames = mutableSetOf<String?>()
             val usesSdks = mutableSetOf<UsesSdk?>()
@@ -253,7 +253,7 @@ public class ApkSet private constructor(
 
                         // Aggregate the apk's manifest values
                         val manifest = apkEntry.innerApk.manifest
-                        appIds.add(manifest.`package`.value)
+                        appIds.add(manifest.`package`)
                         versionCodes.add(manifest.versionCode)
                         versionNames.add(manifest.versionName)
                         usesSdks.add(manifest.usesSdk)
@@ -383,7 +383,7 @@ public class ApkSet private constructor(
 
             // Start combining the values discovered from each base APK into a single value (barring disagreements)
             val appId = appIds.singleOrNull() ?: return ParseApkSetResult.Error.AppIdInconsistentError
-            if (metadata.packageName != appId) {
+            if (metadata.packageName != appId.value) {
                 return ParseApkSetResult.Error.AppIdInconsistentError
             }
 

--- a/console/src/main/kotlin/app/accrescent/parcelo/console/data/net/ApiError.kt
+++ b/console/src/main/kotlin/app/accrescent/parcelo/console/data/net/ApiError.kt
@@ -17,19 +17,19 @@ class ApiError private constructor(
 
         fun apkSetInvalid(message: String) = ApiError(2, "APK set is invalid", message)
 
-        fun apkSetUnsupported(message: String) = ApiError(3, "APK set unsupported", message)
+        fun apkSetUnsupported(message: String) = ApiError(3, "APK set is unsupported", message)
 
-        fun apkSetSignature(message: String) = ApiError(4, "APK set incorrectly signed", message)
+        fun apkSetSignature(message: String) = ApiError(4, "APK set is incorrectly signed", message)
 
-        fun apkSetDebuggable(message: String) = ApiError(5, "APK set in debug mode", message)
+        fun apkSetDebuggable(message: String) = ApiError(5, "APK set is in debug mode", message)
 
-        fun apkSetTestable(message: String) = ApiError(6, "APK set in test mode", message)
+        fun apkSetTestable(message: String) = ApiError(6, "APK set is in test mode", message)
 
         fun apkFormat(message: String) = ApiError(7, "Could not parse APK", message)
 
         fun apkInvalid(message: String) = ApiError(8, "APK is invalid", message)
 
-        fun apkSignature(message: String) = ApiError(9, "APK incorrectly signed", message)
+        fun apkSignature(message: String) = ApiError(9, "APK is incorrectly signed", message)
 
         fun iconImageFormat() =
             ApiError(10, "Image is not in an acceptable format", "Icon must be a PNG")

--- a/console/src/main/kotlin/app/accrescent/parcelo/console/data/net/ApiError.kt
+++ b/console/src/main/kotlin/app/accrescent/parcelo/console/data/net/ApiError.kt
@@ -13,134 +13,113 @@ class ApiError private constructor(
     val message: String,
 ) {
     companion object {
-        fun androidManifest(message: String) = ApiError(1, "Invalid Android manifest", message)
-        fun apkFormat(message: String) = ApiError(2, "APK parsing failed", message)
-        fun debugCertificate(message: String) = ApiError(3, "Debug certificate detected", message)
-        fun signatureVerification(message: String) =
-            ApiError(4, "Signature verification failed", message)
+        fun apkSetFormat(message: String) = ApiError(1, "Could not parse APK set", message)
 
-        fun signatureVersion(message: String) = ApiError(5, "Signature version(s) invalid", message)
-        fun zipFormat(message: String) = ApiError(6, "ZIP format error", message)
-        fun apksNotFound(message: String) = ApiError(7, "APKs not found", message)
-        fun baseApkNotFound(message: String) = ApiError(8, "Base APK not found", message)
-        fun baseApkTargetSdkNotFound(message: String) =
-            ApiError(9, "Base APK target SDK not found", message)
+        fun apkSetInvalid(message: String) = ApiError(2, "APK set is invalid", message)
 
-        fun baseApkVersionNameNotFound(message: String) =
-            ApiError(10, "Base APK version name not found", message)
+        fun apkSetUnsupported(message: String) = ApiError(3, "APK set unsupported", message)
 
-        fun bundletoolMetadata(message: String) =
-            ApiError(11, "Invalid bundletool metadata", message)
+        fun apkSetSignature(message: String) = ApiError(4, "APK set incorrectly signed", message)
 
-        fun bundletoolVersion(message: String) = ApiError(12, "Invalid bundletool version", message)
-        fun bundletoolVersionNotFound(message: String) =
-            ApiError(13, "Bundletool vesrion not found", message)
+        fun apkSetDebuggable(message: String) = ApiError(5, "APK set in debug mode", message)
 
-        fun debuggable(message: String) = ApiError(14, "Application is debuggable", message)
-        fun duplicateSplits(message: String) =
-            ApiError(15, "Duplicate split APKs detected", message)
+        fun apkSetTestable(message: String) = ApiError(6, "APK set in test mode", message)
 
-        fun invalidSplitName(message: String) =
-            ApiError(16, "Invalid split name encountered", message)
+        fun apkFormat(message: String) = ApiError(7, "Could not parse APK", message)
 
-        fun manifestInfoInconsistent(message: String) =
-            ApiError(17, "Inconsistent manifest info", message)
+        fun apkInvalid(message: String) = ApiError(8, "APK is invalid", message)
 
-        fun signingCertMismatch(message: String) =
-            ApiError(18, "Signing certificates don't match", message)
+        fun apkSignature(message: String) = ApiError(9, "APK incorrectly signed", message)
 
-        fun targetSdkNotFound(message: String) = ApiError(19, "Target SDK not found", message)
-        fun testOnly(message: String) = ApiError(20, "Application is test only", message)
-        fun versionNameNotFound(message: String) = ApiError(21, "Version name not found", message)
         fun iconImageFormat() =
-            ApiError(22, "Image is not in an acceptable format", "Icon must be a PNG")
+            ApiError(10, "Image is not in an acceptable format", "Icon must be a PNG")
 
         fun imageResolution() = ApiError(
-            23,
+            11,
             "Image is not in an acceptable resolution",
             "Image resolution must be 512 x 512",
         )
 
         fun labelLength() = ApiError(
-            24,
+            12,
             "Label has invalid length",
             "Label length must be between 3 and 30 characters long (inclusive)",
         )
 
         fun unknownPartName(partName: String?) =
-            ApiError(25, "Unknown part name encountered", "Unknown part name \"$partName\"")
+            ApiError(13, "Unknown part name encountered", "Unknown part name \"$partName\"")
 
         fun appAlreadyExists() =
-            ApiError(26, "App already exists", "An app with this ID already exists")
+            ApiError(14, "App already exists", "An app with this ID already exists")
 
         fun minTargetSdk(min: Int, actual: Int) = ApiError(
-            27,
+            15,
             "Target SDK is too small",
             "Target SDK $actual is smaller than the minimum $min",
         )
 
         fun minBundletoolVersion(min: String, actual: String) = ApiError(
-            28,
+            16,
             "Bundletool version is too small",
             "Bundletool version $actual is smaller than the minimum $min",
         )
 
         fun missingPartName() = ApiError(
-            29,
+            17,
             "Missing request part names",
             "An expected part or parts is missing from the request",
         )
 
         fun invalidUuid(id: String) = ApiError(
-            30,
+            18,
             "Invalid UUID",
             "The ID \"$id\" supplied in the request is not a valid UUID",
         )
 
         fun draftNotFound(id: UUID) =
-            ApiError(31, "Draft not found", "A draft with id \"$id\" does not exist")
+            ApiError(19, "Draft not found", "A draft with id \"$id\" does not exist")
 
         fun reviewerAlreadyAssigned() = ApiError(
-            32,
+            20,
             "Reviewer already assigned",
             "A reviewer has already been assigned to this object",
         )
 
         fun alreadyReviewed() =
-            ApiError(33, "Already reviewed", "This object has already been reviewed")
+            ApiError(21, "Already reviewed", "This object has already been reviewed")
 
         fun reviewForbidden() = ApiError(
-            34,
+            22,
             "Review forbidden",
             "This user does not have sufficient access rights to review this object",
         )
 
         fun publishForbidden() = ApiError(
-            35,
+            23,
             "Publish forbidden",
             "This user does not have sufficient access rights to publish this object",
         )
 
         fun updateCreationForbidden() = ApiError(
-            36,
+            24,
             "Update forbidden",
             "This user does not have sufficient permissions to create an update for this app",
         )
 
         fun updateNotFound(id: UUID) =
-            ApiError(37, "Update not found", "An update with id \"$id\" does not exist")
+            ApiError(25, "Update not found", "An update with id \"$id\" does not exist")
 
         fun appNotFound(id: String) =
-            ApiError(38, "App not found", "An app with id \"$id\" does not exist")
+            ApiError(26, "App not found", "An app with id \"$id\" does not exist")
 
         fun readForbidden() = ApiError(
-            39,
+            27,
             "Read forbidden",
             "This user does not have sufficient access rights to read this object",
         )
 
         fun updateVersionTooLow(updateVersion: Int, appVersion: Int) = ApiError(
-            40,
+            28,
             "Update version is too low",
             "Update version code \"$updateVersion\" is less than published app version \"$appVersion\"",
         )
@@ -149,44 +128,61 @@ class ApiError private constructor(
 
 fun toApiError(error: ParseApkResult.Error): ApiError = with(error) {
     when (this) {
-        ParseApkResult.Error.AndroidManifestError -> ApiError.androidManifest(message)
-        ParseApkResult.Error.ApkFormatError -> ApiError.apkFormat(message)
-        ParseApkResult.Error.DebugCertificateError -> ApiError.debugCertificate(message)
-        ParseApkResult.Error.SignatureVerificationError -> ApiError.signatureVerification(message)
-        ParseApkResult.Error.SignatureVersionError -> ApiError.signatureVersion(message)
-        ParseApkResult.Error.ZipFormatError -> ApiError.zipFormat(message)
+        ParseApkResult.Error.AndroidManifestError -> ApiError.apkInvalid(message)
+        ParseApkResult.Error.ApkFormatError -> ApiError.apkInvalid(message)
+        ParseApkResult.Error.DebugCertificateError -> ApiError.apkSignature(message)
+        ParseApkResult.Error.SignatureVerificationError -> ApiError.apkSignature(message)
+        ParseApkResult.Error.SignatureVersionError -> ApiError.apkSignature(message)
+        ParseApkResult.Error.ZipFormatError -> ApiError.apkFormat(message)
     }
 }
 
 fun toApiError(error: ParseApkSetResult.Error): ApiError = with(error) {
     when (this) {
+        is ParseApkSetResult.Error.MetadataParseError -> ApiError.apkSetFormat(message)
         is ParseApkSetResult.Error.ApkParseError -> toApiError(this.error)
-        ParseApkSetResult.Error.ApksNotFoundError -> ApiError.apksNotFound(message)
-        ParseApkSetResult.Error.BaseApkNotFoundError -> ApiError.baseApkNotFound(message)
-        ParseApkSetResult.Error.BaseApkTargetSdkUnspecifiedError -> ApiError.baseApkTargetSdkNotFound(
-            message
-        )
-
-        ParseApkSetResult.Error.BaseApkVersionNameUnspecifiedError -> ApiError.baseApkVersionNameNotFound(
-            message
-        )
-
-        ParseApkSetResult.Error.BundletoolMetadataError -> ApiError.bundletoolMetadata(message)
-        ParseApkSetResult.Error.BundletoolVersionError -> ApiError.bundletoolVersion(message)
-        ParseApkSetResult.Error.BundletoolVersionNotFoundError -> ApiError.bundletoolVersionNotFound(
-            message
-        )
-
-        ParseApkSetResult.Error.DebuggableError -> ApiError.debuggable(message)
-        ParseApkSetResult.Error.DuplicateSplitError -> ApiError.duplicateSplits(message)
-        is ParseApkSetResult.Error.InvalidSplitNameError -> ApiError.invalidSplitName(message)
-        ParseApkSetResult.Error.ManifestInfoInconsistentError -> ApiError.manifestInfoInconsistent(
-            message
-        )
-
-        ParseApkSetResult.Error.SigningCertMismatchError -> ApiError.signingCertMismatch(message)
-        ParseApkSetResult.Error.TargetSdkNotFoundError -> ApiError.targetSdkNotFound(message)
-        ParseApkSetResult.Error.TestOnlyError -> ApiError.testOnly(message)
-        ParseApkSetResult.Error.VersionNameNotFoundError -> ApiError.versionNameNotFound(message)
+        is ParseApkSetResult.Error.SigningCertMismatchError -> ApiError.apkSetSignature(message)
+        is ParseApkSetResult.Error.DebuggableError -> ApiError.apkSetDebuggable(message)
+        is ParseApkSetResult.Error.TestOnlyError -> ApiError.apkSetTestable(message)
+        is ParseApkSetResult.Error.ManifestInfoInconsistentError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.ZipFormatError -> ApiError.apkSetFormat(message)
+        is ParseApkSetResult.Error.MetadataNotFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.ApksNotFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.BundletoolVersionError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.MetadataUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.VariantsNotFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.VariantTargetingUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.VariantTargetsNothingError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.VariantSDKUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.DuplicateVariantError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.ApkSetUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.ModuleUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.ModuleTargetingUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.ApkDescriptionUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.BaseApkDescriptionInconsistentError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.DuplicateBaseSplitsError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.MultipleBaseApkDescriptionsError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.NoBaseSplitsFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.MultipleBaseSplitsFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.DuplicateSplitPathsError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.ApkTargetingUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.AbiUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.LangUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.DensityUnsupportedError -> ApiError.apkSetUnsupported(message)
+        is ParseApkSetResult.Error.ApkTargetsNothingError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.MultipleApkDescriptionsError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.SplitIdInconsistentError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.NoSplitsFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.MultipleSplitsFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.BaseApkNotFoundError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.UnaccountedSplitsError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.AppIdInconsistentError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.VersionCodeInconsistentError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.VersionNameUnspecifiedError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.VersionNameInconsistentError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.SdkUnspecifiedError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.SdkInconsistentError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.TargetSdkUnspecifiedError -> ApiError.apkSetInvalid(message)
+        is ParseApkSetResult.Error.ReviewIssueInconsistentError -> ApiError.apkSetInvalid(message)
     }
 }

--- a/repository/src/main/kotlin/app/accrescent/parcelo/repository/data/net/RepoData.kt
+++ b/repository/src/main/kotlin/app/accrescent/parcelo/repository/data/net/RepoData.kt
@@ -8,6 +8,8 @@ data class RepoData(
     val version: String,
     @SerialName("version_code")
     val versionCode: Int,
+    @SerialName("base_splits")
+    val bases: Set<String>,
     @SerialName("abi_splits")
     val abiSplits: Set<String>,
     @SerialName("density_splits")

--- a/repository/src/main/kotlin/app/accrescent/parcelo/repository/data/net/RepoData.kt
+++ b/repository/src/main/kotlin/app/accrescent/parcelo/repository/data/net/RepoData.kt
@@ -1,19 +1,28 @@
 package app.accrescent.parcelo.repository.data.net
 
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.*
 
 @Serializable
 data class RepoData(
     val version: String,
     @SerialName("version_code")
     val versionCode: Int,
-    @SerialName("base_splits")
-    val bases: Set<String>,
-    @SerialName("abi_splits")
-    val abiSplits: Set<String>,
-    @SerialName("density_splits")
-    val densitySplits: Set<String>,
-    @SerialName("lang_splits")
-    val langSplits: Set<String>,
+    @SerialName("apk_groups")
+    val apkGroups: SortedMap<Int, ApkGroup>,
+)
+
+@Serializable
+data class ApkGroup(
+    @SerialName("base_split_ids")
+    @Contextual
+    val baseSplitId: UUID,
+    @SerialName("abi_split_ids")
+    val abiSplitIds: Map<String, @Contextual UUID>,
+    @SerialName("lang_split_ids")
+    val langSplitIds: Map<String, @Contextual UUID>,
+    @SerialName("density_split_ids")
+    val densitySplitIDs: Map<String, @Contextual UUID>,
 )

--- a/repository/src/main/kotlin/app/accrescent/parcelo/repository/routes/Apps.kt
+++ b/repository/src/main/kotlin/app/accrescent/parcelo/repository/routes/Apps.kt
@@ -200,6 +200,7 @@ private fun publish(
     val repoData = RepoData(
         version = metadata.versionName,
         versionCode = metadata.versionCode,
+        bases = metadata.bases,
         abiSplits = metadata.abiSplits.map { it.replace("_", "-") }.toSet(),
         langSplits = metadata.langSplits,
         densitySplits = metadata.densitySplits,


### PR DESCRIPTION
This PR intends to refactor the ApkSet parser in order to do the following:
- Organize APK information by variant instead of simply as a pile of splits. This allows APKs with similar splits but different SDK targetings (and thus compression formats) to be used by the client.
- Use and verify `toc.pb` when uploading APKs. In this case, `toc.pb` must one or more variants that collectively link all APKs in the set to a split usable by the repository, without any duplicates, inconsistencies, missing elements, or any other kind of invalid information.
- Error out if anything we don't support or handle is detected. This includes functionality like feature/asset modules, advanced targeting functionality, etc. This way, malformed APKs will not be accidentally put into the app repository, and forwards compatibility will be retained for future repodata versions.

As for the main devconsole:
- Publishing now assigns random UUIDs to each apk in the ApkSet. These UUIDs are then linked to their split in a mapping. This is largely as futureproofing, as the spec for exactly describing the split parameters in an APK name would likely grow more complex if more types of targeting are implemented.
- These APK mappings are organized in groups now, based around their minimum SDK. Note that an APK can be referenced in multiple groups, as they are in APK sets too.
- All APK set parsing API errors have been aggressively simplified into general categories to accommodate the very large amount of errors that the APK set parser can now produce.

This is marked as a draft since the necessary portions of the frontend to test that publishing works is not complete yet.