### PR TITLE
Fix internal server error when deleting app draft's default listing

### DIFF
--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
@@ -963,11 +963,11 @@ private class InMemoryAppDraftRepository(
 
     override fun updateDefaultListing(
         appDraftId: String,
-        defaultAppDraftListingId: String,
+        defaultAppDraftListingId: Option<String>,
     ): DataStoreResult<Unit> = runCatchingSql {
         val sql = "UPDATE app_drafts SET default_app_draft_listing_id = ? WHERE id = ?"
         connection.prepareStatement(sql).use { stmt ->
-            stmt.setString(1, defaultAppDraftListingId)
+            stmt.setString(1, defaultAppDraftListingId.getOrNull())
             stmt.setString(2, appDraftId)
             stmt.executeSingleUpdate().bind()
         }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
@@ -83,6 +83,7 @@ import app.accrescent.server.parcelo.domain.ports.driving.console.UploadAppDraft
 import app.accrescent.server.parcelo.domain.ports.driving.console.toServerError
 import arrow.core.Either
 import arrow.core.None
+import arrow.core.Some
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.google.protobuf.InvalidProtocolBufferException
@@ -356,7 +357,7 @@ class AppDraftApiImpl(
             ensure(listingExists) { AppDraftListingNotFoundError(request.defaultAppDraftListingId) }
 
             tx.appDrafts
-                .updateDefaultListing(request.appDraftId, request.defaultAppDraftListingId)
+                .updateDefaultListing(request.appDraftId, Some(request.defaultAppDraftListingId))
                 .bindMapLeft(::toServerError)
         }
             .bindMapLeft(::toServerError)
@@ -718,6 +719,14 @@ class AppDraftApiImpl(
             // App draft is guaranteed to exist since permission is granted
             val appDraft = tx.appDrafts.requireById(listing.appDraftId).bindMapLeft(::toServerError)
             ensure(appDraft !is DataAppDraft.Submitted) { AppDraftSubmittedError(listing.appDraftId) }
+
+            val isDefaultListing = appDraft.optionalDefaultAppDraftListingId
+                .isSome { it == request.appDraftListingId }
+            if (isDefaultListing) {
+                tx.appDrafts
+                    .updateDefaultListing(listing.appDraftId, None)
+                    .bindMapLeft(::toServerError)
+            }
 
             tx.appDrafts.deleteListingById(request.appDraftListingId).bindMapLeft(::toServerError)
         }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
@@ -396,14 +396,15 @@ abstract class DataStore(private val randomSource: RandomSource) {
          * Updates the default listing of an app draft.
          *
          * @param appDraftId the ID of the app draft to update.
-         * @param defaultAppDraftListingId the ID of app draft listing to set as the default.
+         * @param defaultAppDraftListingId the ID of app draft listing to set as the default, or
+         * [None] to unset the app draft's default listing.
          * @return [DataStoreError.EntityNotFound] if the app draft does not exist, or
          * [DataStoreError.ForeignKeyViolation] if an app draft listing with the given ID does not
          * exist or if the referenced app draft listing is not associated with the given app draft.
          */
         abstract fun updateDefaultListing(
             appDraftId: String,
-            defaultAppDraftListingId: String,
+            defaultAppDraftListingId: Option<String>,
         ): DataStoreResult<Unit>
 
         /**

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/AppDraftApi.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/AppDraftApi.kt
@@ -88,6 +88,11 @@ interface AppDraftApi {
         request: DownloadAppDraftListingIconRequest,
     ): Either<DownloadAppDraftListingIconError, DownloadAppDraftListingIconResponse>
 
+    /**
+     * Deletes an app draft listing.
+     *
+     * If the listing is its app draft's default, the app draft's default listing is unset.
+     */
     fun deleteAppDraftListing(
         callerUserId: String,
         request: DeleteAppDraftListingRequest,

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImplTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImplTest.kt
@@ -260,7 +260,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -334,7 +334,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -474,7 +474,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -544,13 +544,13 @@ class AppDraftApiImplTest {
                     .save(unsubmittedAppDraft("appDraft2", appPackageId = Some("appPackage1")))
                     .bind()
                 tx.appDrafts.saveListing(appDraftListing("appDraftListing2", "appDraft2")).bind()
-                tx.appDrafts.updateDefaultListing("appDraft2", "appDraftListing2").bind()
+                tx.appDrafts.updateDefaultListing("appDraft2", Some("appDraftListing2")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft2", UNIX_EPOCH).bind()
                 tx.appDrafts
                     .save(unsubmittedAppDraft("appDraft1", appPackageId = Some("appPackage2")))
                     .bind()
                 tx.appDrafts.saveListing(appDraftListing("appDraftListing1", "appDraft1")).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
             }.unwrap2()
@@ -572,7 +572,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.apps.saveWithDefaultListing(
                     App("app1", "org1", "appListing1", false),
                     AppListing("appListing1", "app1", DataListingLanguage.EN_US),
@@ -598,7 +598,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
             }
@@ -638,7 +638,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -707,7 +707,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -836,7 +836,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -977,7 +977,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -1150,7 +1150,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -1227,7 +1227,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -1360,7 +1360,7 @@ class AppDraftApiImplTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", ConstantTimestampSource().now()).bind()
                 tx.users.save(user()).bind()
                 tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
@@ -1372,6 +1372,32 @@ class AppDraftApiImplTest {
             val response = appDraftApi.deleteAppDraftListing("user1", request)
 
             assertEquals(AppDraftSubmittedError("appDraft1"), response.unwrapErr())
+        }
+    }
+
+    @Test
+    fun `deleteAppDraftListing unsets default listing if listing is the app draft default`() {
+        InMemoryDataStore.create(DeterministicRandomSource()).unwrap().use { dataStore ->
+            dataStore.migrateToHead().unwrap()
+            dataStore.runTxWithRetry { tx ->
+                tx.organizations.save(organization()).bind()
+                tx.appDrafts.save(unsubmittedAppDraft()).bind()
+                tx.appDrafts.saveListing(appDraftListing()).bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
+                tx.users.save(user()).bind()
+                tx.authz.saveRelationship(organizationOwnerRelationship()).bind()
+            }
+                .unwrap2()
+            val appDraftApi = makeAppDraftApi(dataStore)
+
+            val request = DeleteAppDraftListingRequest("appDraftListing1")
+            appDraftApi.deleteAppDraftListing("user1", request).unwrap()
+            val appDraft = dataStore
+                .runTxWithRetry { tx -> tx.appDrafts.findById("appDraft1").bind() }
+                .unwrap2()
+                .unwrap()
+
+            assertEquals(None, appDraft.optionalDefaultAppDraftListingId)
         }
     }
 

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/async/UploadEventProcessorImplTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/async/UploadEventProcessorImplTest.kt
@@ -203,7 +203,7 @@ class UploadEventProcessorImplTest {
                     tx.appPackages.save(appPackage()).bind()
                     tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                     tx.appDrafts.saveListing(appDraftListing()).bind()
-                    tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                    tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                     tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                     tx.appDrafts.saveUpload(pendingAppDraftUpload()).bind()
                 }

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
@@ -387,7 +387,7 @@ abstract class DataStoreConformanceTest {
                 tx.appPackages.save(originalAppPackage).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
                 .unwrap2()
@@ -1233,7 +1233,7 @@ abstract class DataStoreConformanceTest {
                 .unwrap2()
 
             val result = dataStore.runTxWithRetry { tx ->
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap()
 
@@ -1253,7 +1253,7 @@ abstract class DataStoreConformanceTest {
                 .unwrap2()
 
             val result = dataStore.runTxWithRetry { tx ->
-                tx.appDrafts.updateDefaultListing("appDraft2", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft2", Some("appDraftListing1")).bind()
             }
                 .unwrap()
 
@@ -1266,7 +1266,7 @@ abstract class DataStoreConformanceTest {
         withMigratedDataStore { dataStore ->
 
             val result = dataStore.runTxWithRetry { tx ->
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap()
 
@@ -1285,7 +1285,7 @@ abstract class DataStoreConformanceTest {
                 .unwrap2()
 
             dataStore.runTxWithRetry { tx ->
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap2()
             val appDraft = dataStore
@@ -1294,6 +1294,30 @@ abstract class DataStoreConformanceTest {
                 .unwrap()
 
             assertEquals(Some("appDraftListing1"), appDraft.optionalDefaultAppDraftListingId)
+        }
+    }
+
+    @Test
+    fun `appDrafts updateDefaultListing unsets defaultAppDraftListingId when given None`() {
+        withMigratedDataStore { dataStore ->
+            dataStore.runTxWithRetry { tx ->
+                tx.organizations.save(organization()).bind()
+                tx.appDrafts.save(unsubmittedAppDraft()).bind()
+                tx.appDrafts.saveListing(appDraftListing()).bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
+            }
+                .unwrap2()
+
+            dataStore.runTxWithRetry { tx ->
+                tx.appDrafts.updateDefaultListing("appDraft1", None).bind()
+            }
+                .unwrap2()
+            val appDraft = dataStore
+                .runTxWithRetry { tx -> tx.appDrafts.findById("appDraft1").bind() }
+                .unwrap2()
+                .unwrap()
+
+            assertEquals(None, appDraft.optionalDefaultAppDraftListingId)
         }
     }
 
@@ -1526,7 +1550,7 @@ abstract class DataStoreConformanceTest {
                 tx.appPackages.save(appPackage()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft(appPackageId = Some("appPackage1"))).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap2()
 
@@ -1551,7 +1575,7 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.save(organization()).bind()
                 tx.appDrafts.save(unsubmittedAppDraft()).bind()
                 tx.appDrafts.saveListing(appDraftListing()).bind()
-                tx.appDrafts.updateDefaultListing("appDraft1", "appDraftListing1").bind()
+                tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap2()
 


### PR DESCRIPTION
Attempting to delete an app draft's default listing via AppDraftApi.deleteAppDraftListing() results in an InternalServerError because the DataStore encounters a foreign key violation when attempting to delete the database entity.

To fix this behavior, check when we're attempting to delete the default listing in the deleteAppDraftListing() handler and unset the app draft's default listing beforehand if we are.