### PR TITLE
Remove unneeded Kotlin compiler arguments

### DIFF
--- a/parcelo/build.gradle.kts
+++ b/parcelo/build.gradle.kts
@@ -126,9 +126,6 @@ kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_25
         javaParameters = true
-
-        freeCompilerArgs.add("-Xannotation-default-target=param-property")
-        freeCompilerArgs.add("-Xcontext-parameters")
     }
 }
 

--- a/quarkus-google-cloud-storage/build.gradle.kts
+++ b/quarkus-google-cloud-storage/build.gradle.kts
@@ -32,7 +32,5 @@ kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_25
         javaParameters = true
-
-        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 }


### PR DESCRIPTION
Both of these arguments are not needed since Kotlin 2.4.