### PR TITLE
Remove unnecessary quarkus-core-deployment dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,6 @@ quarkus-awt = { module = "io.quarkus:quarkus-awt" }
 quarkus-bom = { module = "io.quarkus:quarkus-bom", version.ref = "quarkus" }
 quarkus-builder = { module = "io.quarkus:quarkus-builder" }
 quarkus-core = { module = "io.quarkus:quarkus-core" }
-quarkus-core-deployment = { module = "io.quarkus:quarkus-core-deployment" }
 quarkus-devservices-common = { module = "io.quarkus:quarkus-devservices-common" }
 quarkus-extension-processor = { module = "io.quarkus:quarkus-extension-processor", version.ref = "quarkus" }
 quarkus-flyway = { module = "io.quarkus:quarkus-flyway" }


### PR DESCRIPTION
It is no longer needed after 14120f5: "Remove native-only Quarkus extensions".