### PR TITLE
Make maxResults for DB list queries always NonNegativeInt

### DIFF
--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
@@ -534,7 +534,7 @@ private class InMemoryAppDraftRepository(
     override fun findListingsForAppDraftAndUserByQuery(
         appDraftId: String,
         userId: String,
-        maxResults: UInt,
+        maxResults: NonNegativeInt,
         afterLanguage: ListingLanguage?,
     ): DataStoreResult<List<AppDraftListing>> = runCatchingSql {
         val sql = """
@@ -560,7 +560,7 @@ private class InMemoryAppDraftRepository(
             stmt.setString(2, userId)
             stmt.setString(3, afterLanguage?.toString())
             stmt.setString(4, afterLanguage?.toString())
-            stmt.setLong(5, maxResults.toLong())
+            stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
                 val listings = mutableListOf<AppDraftListing>()
                 while (rs.next()) {

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
@@ -472,7 +472,7 @@ private class PostgresqlAppDraftRepository(
     override fun findListingsForAppDraftAndUserByQuery(
         appDraftId: String,
         userId: String,
-        maxResults: UInt,
+        maxResults: NonNegativeInt,
         afterLanguage: ListingLanguage?,
     ): DataStoreResult<List<AppDraftListing>> = runCatchingSql {
         val sql = """
@@ -498,7 +498,7 @@ private class PostgresqlAppDraftRepository(
             stmt.setString(2, userId)
             stmt.setString(3, afterLanguage?.toString())
             stmt.setString(4, afterLanguage?.toString())
-            stmt.setLong(5, maxResults.toLong())
+            stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
                 val listings = mutableListOf<AppDraftListing>()
                 while (rs.next()) {

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
@@ -521,6 +521,14 @@ class AppDraftApiImpl(
         context: CallContext,
         request: ListAppDraftListingsRequest,
     ): Either<ListAppDraftListingsError, ListAppDraftListingsResponse> = either {
+        // We never need a page size beyond Int.MAX_VALUE since we limit the number of app draft
+        // listings per app draft well below that, so we can safely coerce the page size down for
+        // our DataStore query without changing behavior
+        val maxResults = request.pageSize
+            .coerceAtMost(Int.MAX_VALUE.toUInt())
+            .toInt()
+            .let(NonNegativeInt::new)
+            .unwrap()
         val lastLanguage = request.nextPageToken?.let {
             try {
                 val bytes = Base64.UrlSafe.decode(it)
@@ -545,7 +553,7 @@ class AppDraftApiImpl(
                 .findListingsForAppDraftAndUserByQuery(
                     appDraftId = request.appDraftId,
                     userId = userId,
-                    maxResults = request.pageSize,
+                    maxResults = maxResults,
                     afterLanguage = lastLanguage,
                 )
                 .bindMapLeft(::toServerError)

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
@@ -289,7 +289,7 @@ abstract class DataStore(private val randomSource: RandomSource) {
         abstract fun findListingsForAppDraftAndUserByQuery(
             appDraftId: String,
             userId: String,
-            maxResults: UInt,
+            maxResults: NonNegativeInt,
             afterLanguage: ListingLanguage?,
         ): DataStoreResult<List<AppDraftListing>>
 

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
@@ -686,7 +686,12 @@ abstract class DataStoreConformanceTest {
             val listings = dataStore
                 .runTxWithRetry { tx ->
                     tx.appDrafts
-                        .findListingsForAppDraftAndUserByQuery("appDraft1", "user1", 2u, null)
+                        .findListingsForAppDraftAndUserByQuery(
+                            appDraftId = "appDraft1",
+                            userId = "user1",
+                            maxResults = NonNegativeInt.new(2).unwrap(),
+                            afterLanguage = null,
+                        )
                         .bind()
                 }
                 .unwrap2()
@@ -711,7 +716,12 @@ abstract class DataStoreConformanceTest {
             val listings = dataStore
                 .runTxWithRetry { tx ->
                     tx.appDrafts
-                        .findListingsForAppDraftAndUserByQuery("appDraft1", "user2", 1u, null)
+                        .findListingsForAppDraftAndUserByQuery(
+                            appDraftId = "appDraft1",
+                            userId = "user2",
+                            maxResults = NonNegativeInt.new(1).unwrap(),
+                            afterLanguage = null,
+                        )
                         .bind()
                 }
                 .unwrap2()


### PR DESCRIPTION
NonNegativeInt more accurately represents the maxResults domain and is already used for findApiViewsForOrganizationAndUserByQuery(), so we should be consistent and prefer it over UInt across all DataStore list-returning queries.