### PR TITLE
Replace nullable types with Option at API boundaries

### DIFF
--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
@@ -474,7 +474,7 @@ private class InMemoryAppDraftRepository(
         organizationId: String,
         userId: String,
         maxResults: NonNegativeInt,
-        afterAppDraftId: String?,
+        afterAppDraftId: Option<String>,
     ): DataStoreResult<List<AppDraftApiView>> = runCatchingSql {
         val sql = """
             SELECT
@@ -500,8 +500,8 @@ private class InMemoryAppDraftRepository(
         connection.prepareStatement(sql).use { stmt ->
             stmt.setString(1, organizationId)
             stmt.setString(2, userId)
-            stmt.setString(3, afterAppDraftId)
-            stmt.setString(4, afterAppDraftId)
+            stmt.setString(3, afterAppDraftId.getOrNull())
+            stmt.setString(4, afterAppDraftId.getOrNull())
             stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
                 val appDrafts = mutableListOf<AppDraftApiView>()
@@ -535,7 +535,7 @@ private class InMemoryAppDraftRepository(
         appDraftId: String,
         userId: String,
         maxResults: NonNegativeInt,
-        afterLanguage: ListingLanguage?,
+        afterLanguage: Option<ListingLanguage>,
     ): DataStoreResult<List<AppDraftListing>> = runCatchingSql {
         val sql = """
             SELECT
@@ -558,8 +558,8 @@ private class InMemoryAppDraftRepository(
         connection.prepareStatement(sql).use { stmt ->
             stmt.setString(1, appDraftId)
             stmt.setString(2, userId)
-            stmt.setString(3, afterLanguage?.toString())
-            stmt.setString(4, afterLanguage?.toString())
+            stmt.setString(3, afterLanguage.map { it.toString() }.getOrNull())
+            stmt.setString(4, afterLanguage.map { it.toString() }.getOrNull())
             stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
                 val listings = mutableListOf<AppDraftListing>()
@@ -822,8 +822,8 @@ private class InMemoryAppDraftRepository(
 
     override fun updateListing(
         listingId: String,
-        name: String?,
-        shortDescription: String?,
+        name: Option<String>,
+        shortDescription: Option<String>,
     ): DataStoreResult<Unit> = runCatchingSql {
         val sql = """
             UPDATE app_draft_listings
@@ -831,8 +831,8 @@ private class InMemoryAppDraftRepository(
             WHERE id = ?
         """.trimIndent()
         connection.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, name, Types.VARCHAR)
-            stmt.setObject(2, shortDescription, Types.VARCHAR)
+            stmt.setObject(1, name.getOrNull(), Types.VARCHAR)
+            stmt.setObject(2, shortDescription.getOrNull(), Types.VARCHAR)
             stmt.setString(3, listingId)
             stmt.executeSingleUpdate().bind()
         }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
@@ -412,7 +412,7 @@ private class PostgresqlAppDraftRepository(
         organizationId: String,
         userId: String,
         maxResults: NonNegativeInt,
-        afterAppDraftId: String?,
+        afterAppDraftId: Option<String>,
     ): DataStoreResult<List<AppDraftApiView>> = runCatchingSql {
         val sql = """
             SELECT
@@ -438,8 +438,8 @@ private class PostgresqlAppDraftRepository(
         connection.prepareStatement(sql).use { stmt ->
             stmt.setString(1, organizationId)
             stmt.setString(2, userId)
-            stmt.setString(3, afterAppDraftId)
-            stmt.setString(4, afterAppDraftId)
+            stmt.setString(3, afterAppDraftId.getOrNull())
+            stmt.setString(4, afterAppDraftId.getOrNull())
             stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
                 val appDrafts = mutableListOf<AppDraftApiView>()
@@ -473,7 +473,7 @@ private class PostgresqlAppDraftRepository(
         appDraftId: String,
         userId: String,
         maxResults: NonNegativeInt,
-        afterLanguage: ListingLanguage?,
+        afterLanguage: Option<ListingLanguage>,
     ): DataStoreResult<List<AppDraftListing>> = runCatchingSql {
         val sql = """
             SELECT
@@ -496,8 +496,8 @@ private class PostgresqlAppDraftRepository(
         connection.prepareStatement(sql).use { stmt ->
             stmt.setString(1, appDraftId)
             stmt.setString(2, userId)
-            stmt.setString(3, afterLanguage?.toString())
-            stmt.setString(4, afterLanguage?.toString())
+            stmt.setString(3, afterLanguage.map { it.toString() }.getOrNull())
+            stmt.setString(4, afterLanguage.map { it.toString() }.getOrNull())
             stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
                 val listings = mutableListOf<AppDraftListing>()
@@ -786,8 +786,8 @@ private class PostgresqlAppDraftRepository(
 
     override fun updateListing(
         listingId: String,
-        name: String?,
-        shortDescription: String?,
+        name: Option<String>,
+        shortDescription: Option<String>,
     ): DataStoreResult<Unit> = runCatchingSql {
         val sql = """
             UPDATE app_draft_listings
@@ -795,8 +795,8 @@ private class PostgresqlAppDraftRepository(
             WHERE id = ?
         """.trimIndent()
         connection.prepareStatement(sql).use { stmt ->
-            stmt.setObject(1, name, Types.VARCHAR)
-            stmt.setObject(2, shortDescription, Types.VARCHAR)
+            stmt.setObject(1, name.getOrNull(), Types.VARCHAR)
+            stmt.setObject(2, shortDescription.getOrNull(), Types.VARCHAR)
             stmt.setString(3, listingId)
             stmt.executeSingleUpdate().bind()
         }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
@@ -180,7 +180,7 @@ class AppDraftApiImpl(
             .toInt()
             .let(NonNegativeInt::new)
             .unwrap()
-        val lastAppDraftId = request.pageToken?.let {
+        val lastAppDraftId = request.pageToken.map {
             try {
                 val bytes = Base64.UrlSafe.decode(it)
                 val token = ListAppDraftsPageToken.parseFrom(bytes)
@@ -213,9 +213,9 @@ class AppDraftApiImpl(
             .map { it.toApiResource() }
         val nextPageToken = if (appDrafts.isNotEmpty()) {
             val token = listAppDraftsPageToken { this.lastAppDraftId = appDrafts.last().id }
-            Base64.UrlSafe.encode(token.toByteArray())
+            Some(Base64.UrlSafe.encode(token.toByteArray()))
         } else {
-            null
+            None
         }
 
         ListAppDraftsResponse(appDrafts, nextPageToken)
@@ -529,7 +529,7 @@ class AppDraftApiImpl(
             .toInt()
             .let(NonNegativeInt::new)
             .unwrap()
-        val lastLanguage = request.nextPageToken?.let {
+        val lastLanguage = request.nextPageToken.map {
             try {
                 val bytes = Base64.UrlSafe.decode(it)
                 val token = ListAppDraftListingsPageToken.parseFrom(bytes)
@@ -571,9 +571,9 @@ class AppDraftApiImpl(
             }
         val nextPageToken = if (listings.isNotEmpty()) {
             val token = listAppDraftListingsPageToken { this.lastLanguage = listings.last().language }
-            Base64.UrlSafe.encode(token.toByteArray())
+            Some(Base64.UrlSafe.encode(token.toByteArray()))
         } else {
-            null
+            None
         }
 
         ListAppDraftListingsResponse(listings, nextPageToken)

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
@@ -256,14 +256,15 @@ abstract class DataStore(private val randomSource: RandomSource) {
          *
          * @param organizationId the organization to list app drafts from.
          * @param userId the user ID to use for authorization.
-         * @param afterAppDraftId the app draft ID to start listing after.
+         * @param afterAppDraftId the app draft ID to start listing after, or [None] to start from
+         * the beginning.
          * @return the list of app draft API views matching the query.
          */
         abstract fun findApiViewsForOrganizationAndUserByQuery(
             organizationId: String,
             userId: String,
             maxResults: NonNegativeInt,
-            afterAppDraftId: String?,
+            afterAppDraftId: Option<String>,
         ): DataStoreResult<List<AppDraftApiView>>
 
         /**
@@ -283,14 +284,15 @@ abstract class DataStore(private val randomSource: RandomSource) {
          * @param appDraftId the app draft to list listings for.
          * @param userId the user ID to use for authorization.
          * @param maxResults the maximum number of app draft listings to retrieve.
-         * @param afterLanguage the listing language to start listing after.
+         * @param afterLanguage the listing language to start listing after, or [None] to start
+         * from the beginning.
          * @return the list of app draft listings matching the query.
          */
         abstract fun findListingsForAppDraftAndUserByQuery(
             appDraftId: String,
             userId: String,
             maxResults: NonNegativeInt,
-            afterLanguage: ListingLanguage?,
+            afterLanguage: Option<ListingLanguage>,
         ): DataStoreResult<List<AppDraftListing>>
 
         /**
@@ -469,15 +471,15 @@ abstract class DataStore(private val randomSource: RandomSource) {
          * Updates the fields of an app draft listing.
          *
          * @param listingId the ID of the app draft listing to update.
-         * @param name the new name for the listing, or null to leave unchanged.
-         * @param shortDescription the new short description for the listing, or null to leave
+         * @param name the new name for the listing, or [None] to leave unchanged.
+         * @param shortDescription the new short description for the listing, or [None] to leave
          * unchanged.
          * @return [DataStoreError.EntityNotFound] if the listing does not exist.
          */
         abstract fun updateListing(
             listingId: String,
-            name: String?,
-            shortDescription: String?,
+            name: Option<String>,
+            shortDescription: Option<String>,
         ): DataStoreResult<Unit>
 
         /**

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftListingsRequest.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftListingsRequest.kt
@@ -4,6 +4,9 @@
 
 package app.accrescent.server.parcelo.domain.ports.driving.console
 
+import arrow.core.None
+import arrow.core.Option
+
 /**
  * A request for listing app draft listings.
  *
@@ -11,10 +14,10 @@ package app.accrescent.server.parcelo.domain.ports.driving.console
  * @property pageSize the maximum number of app draft listings to return in the response. If
  * unspecified, defaults to 50. All requests with a higher page size will be capped to 50.
  * @property nextPageToken an opaque page continuation token returned in a previous
- * [ListAppDraftListingsResponse]. If unspecified, the first page is returned.
+ * [ListAppDraftListingsResponse]. If [None], the first page is returned.
  */
 data class ListAppDraftListingsRequest(
     val appDraftId: String,
     val pageSize: UInt,
-    val nextPageToken: String?,
+    val nextPageToken: Option<String>,
 )

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftListingsResponse.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftListingsResponse.kt
@@ -4,15 +4,19 @@
 
 package app.accrescent.server.parcelo.domain.ports.driving.console
 
+import arrow.core.None
+import arrow.core.Option
+
 /**
  * Response to listing app draft listings.
  *
  * @property appDraftListings the app draft listings matching the request parameters in alphabetical
  * order by their language's BCP-47 codes.
  * @property nextPageToken an opaque token which, if passed to another invocation of
- * [AppDraftApi.listAppDraftListings], will return the next page of app draft listings.
+ * [AppDraftApi.listAppDraftListings], will return the next page of app draft listings. [None] if no
+ * further pages remain.
  */
 data class ListAppDraftListingsResponse(
     val appDraftListings: List<AppDraftListing>,
-    val nextPageToken: String?,
+    val nextPageToken: Option<String>,
 )

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftsRequest.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftsRequest.kt
@@ -4,8 +4,10 @@
 
 package app.accrescent.server.parcelo.domain.ports.driving.console
 
+import arrow.core.Option
+
 data class ListAppDraftsRequest(
     val organizationId: String,
     val pageSize: UInt,
-    val pageToken: String?,
+    val pageToken: Option<String>,
 )

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftsResponse.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/ListAppDraftsResponse.kt
@@ -4,4 +4,6 @@
 
 package app.accrescent.server.parcelo.domain.ports.driving.console
 
-data class ListAppDraftsResponse(val appDrafts: List<AppDraft>, val nextPageToken: String?)
+import arrow.core.Option
+
+data class ListAppDraftsResponse(val appDrafts: List<AppDraft>, val nextPageToken: Option<String>)

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/UpdateAppDraftListingRequest.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driving/console/UpdateAppDraftListingRequest.kt
@@ -4,8 +4,10 @@
 
 package app.accrescent.server.parcelo.domain.ports.driving.console
 
+import arrow.core.Option
+
 data class UpdateAppDraftListingRequest(
     val appDraftListingId: String,
-    val name: String?,
-    val shortDescription: String?,
+    val name: Option<String>,
+    val shortDescription: Option<String>,
 )

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImplTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImplTest.kt
@@ -63,10 +63,11 @@ import app.accrescent.server.parcelo.saveAppPackageFromNewUpload
 import app.accrescent.server.parcelo.signInNewUser
 import arrow.core.Either
 import arrow.core.None
+import arrow.core.Option
 import arrow.core.Some
 import arrow.core.right
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.params.ParameterizedTest
@@ -264,7 +265,7 @@ class AppDraftApiImplTest {
             createAppDraft(dataStore, appDraftApi, context2)
 
             val response = appDraftApi
-                .listAppDrafts(context1, ListAppDraftsRequest(organizationId1, 2u, null))
+                .listAppDrafts(context1, ListAppDraftsRequest(organizationId1, 2u, None))
                 .map { it.appDrafts }
 
             assertEquals(
@@ -297,7 +298,7 @@ class AppDraftApiImplTest {
             val appDraftApi = makeAppDraftApi(dataStore)
 
             val response = appDraftApi
-                .listAppDrafts(CallContext(Some("session1")), ListAppDraftsRequest("org1", 1u, null))
+                .listAppDrafts(CallContext(Some("session1")), ListAppDraftsRequest("org1", 1u, None))
                 .map { it.appDrafts }
 
             assertEquals(
@@ -332,7 +333,7 @@ class AppDraftApiImplTest {
             createAppDraft(dataStore, appDraftApi, context1)
 
             val response = appDraftApi
-                .listAppDrafts(context2, ListAppDraftsRequest(organizationId1, 1u, null))
+                .listAppDrafts(context2, ListAppDraftsRequest(organizationId1, 1u, None))
                 .map { it.appDrafts }
 
             assertEquals(emptyList<ApiAppDraft>().right(), response)
@@ -349,7 +350,7 @@ class AppDraftApiImplTest {
             repeat(2) { createAppDraft(dataStore, appDraftApi, context) }
 
             val response = appDraftApi
-                .listAppDrafts(context, ListAppDraftsRequest(organizationId, 1u, null))
+                .listAppDrafts(context, ListAppDraftsRequest(organizationId, 1u, None))
 
             assertInstanceOf<Either.Right<ListAppDraftsResponse>>(response)
             assertEquals(1, response.value.appDrafts.size)
@@ -366,14 +367,14 @@ class AppDraftApiImplTest {
             val appDraftIds = List(2) { createAppDraft(dataStore, appDraftApi, context) }
 
             val allDrafts = mutableListOf<ApiAppDraft>()
-            var pageToken: String? = null
+            var pageToken: Option<String> = None
             do {
                 val response = appDraftApi
                     .listAppDrafts(context, ListAppDraftsRequest(organizationId, 1u, pageToken))
                     .unwrap()
                 allDrafts.addAll(response.appDrafts)
                 pageToken = response.nextPageToken
-            } while (pageToken != null)
+            } while (pageToken.isSome())
 
             assertEquals(appDraftIds.toSet(), allDrafts.map { it.id }.toSet())
         }
@@ -389,10 +390,10 @@ class AppDraftApiImplTest {
             repeat(2) { createAppDraft(dataStore, appDraftApi, context) }
 
             val response = appDraftApi
-                .listAppDrafts(context, ListAppDraftsRequest(organizationId, 1u, null))
+                .listAppDrafts(context, ListAppDraftsRequest(organizationId, 1u, None))
 
             assertInstanceOf<Either.Right<ListAppDraftsResponse>>(response)
-            assertNotNull(response.value.nextPageToken)
+            assertTrue(response.value.nextPageToken.isSome())
         }
     }
 
@@ -884,7 +885,7 @@ class AppDraftApiImplTest {
 
             val response = appDraftApi.listAppDraftListings(
                 context,
-                ListAppDraftListingsRequest(appDraftId1, 2u, null),
+                ListAppDraftListingsRequest(appDraftId1, 2u, None),
             )
                 .map { it.appDraftListings }
 
@@ -916,7 +917,7 @@ class AppDraftApiImplTest {
 
             val response = appDraftApi.listAppDraftListings(
                 context2,
-                ListAppDraftListingsRequest(appDraftId1, 1u, null),
+                ListAppDraftListingsRequest(appDraftId1, 1u, None),
             )
                 .map { it.appDraftListings }
 
@@ -931,7 +932,7 @@ class AppDraftApiImplTest {
             val context = signIn(dataStore)
             val appDraftApi = makeAppDraftApi(dataStore)
 
-            val request = UpdateAppDraftListingRequest("appDraftListing1", null, null)
+            val request = UpdateAppDraftListingRequest("appDraftListing1", None, None)
             val response = appDraftApi.updateAppDraftListing(context, request)
 
             assertEquals(InsufficientPermissionError, response.unwrapErr())
@@ -953,7 +954,7 @@ class AppDraftApiImplTest {
                 .unwrap2()
             val appDraftApi = makeAppDraftApi(dataStore)
 
-            val request = UpdateAppDraftListingRequest("appDraftListing1", null, null)
+            val request = UpdateAppDraftListingRequest("appDraftListing1", None, None)
             val response = appDraftApi.updateAppDraftListing(CallContext(Some("session1")), request)
 
             assertEquals(AppDraftSubmittedError("appDraft1"), response.unwrapErr())
@@ -971,8 +972,8 @@ class AppDraftApiImplTest {
 
             val request = UpdateAppDraftListingRequest(
                 appDraftListingId = appDraftListingId,
-                name = "App Name",
-                shortDescription = "App Short Description",
+                name = Some("App Name"),
+                shortDescription = Some("App Short Description"),
             )
             appDraftApi.updateAppDraftListing(context, request).unwrap()
             val getResponse = appDraftApi
@@ -1269,7 +1270,7 @@ class AppDraftApiImplTest {
                     api.getAppDraft(context, GetAppDraftRequest("appDraft1"))
                 },
                 "listAppDrafts" to { api, context ->
-                    api.listAppDrafts(context, ListAppDraftsRequest("org1", 1u, null))
+                    api.listAppDrafts(context, ListAppDraftsRequest("org1", 1u, None))
                 },
                 "uploadAppDraft" to { api, context ->
                     api.uploadAppDraft(context, UploadAppDraftRequest("appDraft1"))
@@ -1301,12 +1302,12 @@ class AppDraftApiImplTest {
                     api.getAppDraftListing(context, GetAppDraftListingRequest("appDraftListing1"))
                 },
                 "listAppDraftListings" to { api, context ->
-                    api.listAppDraftListings(context, ListAppDraftListingsRequest("appDraft1", 1u, null))
+                    api.listAppDraftListings(context, ListAppDraftListingsRequest("appDraft1", 1u, None))
                 },
                 "updateAppDraftListing" to { api, context ->
                     api.updateAppDraftListing(
                         context,
-                        UpdateAppDraftListingRequest("appDraftListing1", null, null),
+                        UpdateAppDraftListingRequest("appDraftListing1", None, None),
                     )
                 },
                 "uploadAppDraftListingIcon" to { api, context ->

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
@@ -543,7 +543,7 @@ abstract class DataStoreConformanceTest {
                             "org1",
                             "user1",
                             NonNegativeInt.new(2).unwrap(),
-                            null,
+                            None,
                         )
                         .bind()
                 }
@@ -569,7 +569,7 @@ abstract class DataStoreConformanceTest {
                             "org1",
                             "user2",
                             NonNegativeInt.new(1).unwrap(),
-                            null,
+                            None,
                         )
                         .bind()
                 }
@@ -595,7 +595,7 @@ abstract class DataStoreConformanceTest {
                             "org1",
                             "user1",
                             NonNegativeInt.new(1).unwrap(),
-                            null,
+                            None,
                         )
                         .bind()
                 }
@@ -621,7 +621,7 @@ abstract class DataStoreConformanceTest {
                             "org1",
                             "user1",
                             NonNegativeInt.new(2).unwrap(),
-                            "appDraft1",
+                            Some("appDraft1"),
                         )
                         .bind()
                 }
@@ -690,7 +690,7 @@ abstract class DataStoreConformanceTest {
                             appDraftId = "appDraft1",
                             userId = "user1",
                             maxResults = NonNegativeInt.new(2).unwrap(),
-                            afterLanguage = null,
+                            afterLanguage = None,
                         )
                         .bind()
                 }
@@ -720,7 +720,7 @@ abstract class DataStoreConformanceTest {
                             appDraftId = "appDraft1",
                             userId = "user2",
                             maxResults = NonNegativeInt.new(1).unwrap(),
-                            afterLanguage = null,
+                            afterLanguage = None,
                         )
                         .bind()
                 }
@@ -1500,7 +1500,7 @@ abstract class DataStoreConformanceTest {
     fun `appDrafts updateListing returns EntityNotFound for non-existent app draft listing`() {
         withMigratedDataStore { dataStore ->
             val result = dataStore.runTxWithRetry { tx ->
-                tx.appDrafts.updateListing("appDraftListing1", null, null).bind()
+                tx.appDrafts.updateListing("appDraftListing1", None, None).bind()
             }
                 .unwrap()
 
@@ -1520,7 +1520,7 @@ abstract class DataStoreConformanceTest {
                 .unwrap2()
 
             dataStore.runTxWithRetry { tx ->
-                tx.appDrafts.updateListing("appDraftListing1", null, null).bind()
+                tx.appDrafts.updateListing("appDraftListing1", None, None).bind()
             }
                 .unwrap2()
             val foundListing = dataStore
@@ -1543,7 +1543,11 @@ abstract class DataStoreConformanceTest {
 
             dataStore.runTxWithRetry { tx ->
                 tx.appDrafts
-                    .updateListing("appDraftListing1", "Updated App Name", "Updated App Description")
+                    .updateListing(
+                        listingId = "appDraftListing1",
+                        name = Some("Updated App Name"),
+                        shortDescription = Some("Updated App Description"),
+                    )
                     .bind()
             }
                 .unwrap2()


### PR DESCRIPTION
It's already an established pattern in our codebase to use arrow.core.Option instead of Kotlin's nullable types at API boundaries because of the better type safety it offers, e.g., T?? implicitly collapses to T?, but Option<Option<T>> is representable. However, not everywhere uses this pattern, making our use inconsistent.

This commit migrates the rest of the new codebase to use Option instead of nullable types at all API boundaries (e.g., function signatures, public fields, public constructors) for better consistency and type safety.