### PR TITLE
Separate app draft listing read and write models

### DIFF
--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
@@ -19,7 +19,7 @@ import app.accrescent.server.parcelo.domain.authn.ExternalUserId
 import app.accrescent.server.parcelo.domain.crypto.Sha256Hash
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.App
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftApiView
-import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListing
+import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListingApiView
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListingIconUploadProcessingResult
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftUploadProcessingError
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppListing
@@ -297,6 +297,27 @@ private class InMemoryAppDraftRepository(
         }
     }
 
+    override fun createListing(
+        id: String,
+        appDraftId: String,
+        language: ListingLanguage,
+        name: String,
+        shortDescription: String,
+    ): DataStoreResult<Unit> = runCatchingSql {
+        val sql = """
+            INSERT INTO app_draft_listings (id, app_draft_id, language, name, short_description)
+            VALUES (?, ?, ?, ?, ?)
+        """.trimIndent()
+        connection.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, id)
+            stmt.setString(2, appDraftId)
+            stmt.setString(3, language.toString())
+            stmt.setString(4, name)
+            stmt.setString(5, shortDescription)
+            stmt.executeSingleUpdate().bind()
+        }
+    }
+
     override fun deleteById(
         id: String,
         blobDeleteTime: OffsetDateTime,
@@ -513,9 +534,9 @@ private class InMemoryAppDraftRepository(
         }
     }
 
-    override fun findListingById(
+    override fun findListingApiViewById(
         id: String,
-    ): DataStoreResult<Option<AppDraftListing>> = runCatchingSql {
+    ): DataStoreResult<Option<AppDraftListingApiView>> = runCatchingSql {
         val sql = """
             SELECT id, app_draft_id, language, name, short_description
             FROM app_draft_listings
@@ -526,17 +547,17 @@ private class InMemoryAppDraftRepository(
             stmt.executeQuery().use { rs ->
                 if (!rs.next()) return@use None
 
-                Some(rs.readAppDraftListing().bind())
+                Some(rs.readAppDraftListingApiView().bind())
             }
         }
     }
 
-    override fun findListingsForAppDraftAndUserByQuery(
+    override fun findListingApiViewsForAppDraftAndUserByQuery(
         appDraftId: String,
         userId: String,
         maxResults: NonNegativeInt,
         afterLanguage: Option<ListingLanguage>,
-    ): DataStoreResult<List<AppDraftListing>> = runCatchingSql {
+    ): DataStoreResult<List<AppDraftListingApiView>> = runCatchingSql {
         val sql = """
             SELECT
                 app_draft_listings.id,
@@ -562,9 +583,9 @@ private class InMemoryAppDraftRepository(
             stmt.setString(4, afterLanguage.map { it.toString() }.getOrNull())
             stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
-                val listings = mutableListOf<AppDraftListing>()
+                val listings = mutableListOf<AppDraftListingApiView>()
                 while (rs.next()) {
-                    listings.add(rs.readAppDraftListing().bind())
+                    listings.add(rs.readAppDraftListingApiView().bind())
                 }
                 listings
             }
@@ -742,21 +763,6 @@ private class InMemoryAppDraftRepository(
         connection.prepareStatement(sql).use { stmt ->
             stmt.setString(1, appDraftId)
             stmt.executeQuery().use { rs -> rs.getSelectExistsResult().bind() }
-        }
-    }
-
-    override fun saveListing(listing: AppDraftListing): DataStoreResult<Unit> = runCatchingSql {
-        val sql = """
-            INSERT INTO app_draft_listings (id, app_draft_id, language, name, short_description)
-            VALUES (?, ?, ?, ?, ?)
-        """.trimIndent()
-        connection.prepareStatement(sql).use { stmt ->
-            stmt.setString(1, listing.id)
-            stmt.setString(2, listing.appDraftId)
-            stmt.setString(3, listing.language.toString())
-            stmt.setString(4, listing.name)
-            stmt.setString(5, listing.shortDescription)
-            stmt.executeSingleUpdate().bind()
         }
     }
 
@@ -1495,11 +1501,11 @@ private fun ResultSet.readAppDraftApiView(): DataStoreResult<AppDraftApiView> = 
 }
 
 /**
- * Reads an [AppDraftListing] from the current row, which must expose every `app_draft_listings`
- * column selected by this repository.
+ * Reads an [AppDraftListingApiView] from the current row, which must expose every
+ * `app_draft_listings` column selected by this repository.
  */
-private fun ResultSet.readAppDraftListing(): DataStoreResult<AppDraftListing> = either {
-    AppDraftListing(
+private fun ResultSet.readAppDraftListingApiView(): DataStoreResult<AppDraftListingApiView> = either {
+    AppDraftListingApiView(
         id = requireString("id").bind(),
         appDraftId = requireString("app_draft_id").bind(),
         language = ListingLanguage.fromString(requireString("language").bind())

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
@@ -19,7 +19,7 @@ import app.accrescent.server.parcelo.domain.authn.ExternalUserId
 import app.accrescent.server.parcelo.domain.crypto.Sha256Hash
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.App
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftApiView
-import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListing
+import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListingApiView
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListingIconUploadProcessingResult
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftUploadProcessingError
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppListing
@@ -230,6 +230,27 @@ private class PostgresqlAppDraftRepository(
             stmt.setString(1, appDraftId)
             stmt.setString(2, organizationId)
             stmt.setObject(3, createTime)
+            stmt.executeSingleUpdate().bind()
+        }
+    }
+
+    override fun createListing(
+        id: String,
+        appDraftId: String,
+        language: ListingLanguage,
+        name: String,
+        shortDescription: String,
+    ): DataStoreResult<Unit> = runCatchingSql {
+        val sql = """
+            INSERT INTO app_draft_listings (id, app_draft_id, language, name, short_description)
+            VALUES (?, ?, ?, ?, ?)
+        """.trimIndent()
+        connection.prepareStatement(sql).use { stmt ->
+            stmt.setString(1, id)
+            stmt.setString(2, appDraftId)
+            stmt.setString(3, language.toString())
+            stmt.setString(4, name)
+            stmt.setString(5, shortDescription)
             stmt.executeSingleUpdate().bind()
         }
     }
@@ -451,9 +472,9 @@ private class PostgresqlAppDraftRepository(
         }
     }
 
-    override fun findListingById(
+    override fun findListingApiViewById(
         id: String,
-    ): DataStoreResult<Option<AppDraftListing>> = runCatchingSql {
+    ): DataStoreResult<Option<AppDraftListingApiView>> = runCatchingSql {
         val sql = """
             SELECT id, app_draft_id, language, name, short_description
             FROM app_draft_listings
@@ -464,17 +485,17 @@ private class PostgresqlAppDraftRepository(
             stmt.executeQuery().use { rs ->
                 if (!rs.next()) return@use None
 
-                Some(rs.readAppDraftListing().bind())
+                Some(rs.readAppDraftListingApiView().bind())
             }
         }
     }
 
-    override fun findListingsForAppDraftAndUserByQuery(
+    override fun findListingApiViewsForAppDraftAndUserByQuery(
         appDraftId: String,
         userId: String,
         maxResults: NonNegativeInt,
         afterLanguage: Option<ListingLanguage>,
-    ): DataStoreResult<List<AppDraftListing>> = runCatchingSql {
+    ): DataStoreResult<List<AppDraftListingApiView>> = runCatchingSql {
         val sql = """
             SELECT
                 app_draft_listings.id,
@@ -500,9 +521,9 @@ private class PostgresqlAppDraftRepository(
             stmt.setString(4, afterLanguage.map { it.toString() }.getOrNull())
             stmt.setInt(5, maxResults.value)
             stmt.executeQuery().use { rs ->
-                val listings = mutableListOf<AppDraftListing>()
+                val listings = mutableListOf<AppDraftListingApiView>()
                 while (rs.next()) {
-                    listings.add(rs.readAppDraftListing().bind())
+                    listings.add(rs.readAppDraftListingApiView().bind())
                 }
                 listings
             }
@@ -680,21 +701,6 @@ private class PostgresqlAppDraftRepository(
         connection.prepareStatement(sql).use { stmt ->
             stmt.setString(1, appDraftId)
             stmt.executeQuery().use { rs -> rs.getSelectExistsResult().bind() }
-        }
-    }
-
-    override fun saveListing(listing: AppDraftListing): DataStoreResult<Unit> = runCatchingSql {
-        val sql = """
-            INSERT INTO app_draft_listings (id, app_draft_id, language, name, short_description)
-            VALUES (?, ?, ?, ?, ?)
-        """.trimIndent()
-        connection.prepareStatement(sql).use { stmt ->
-            stmt.setString(1, listing.id)
-            stmt.setString(2, listing.appDraftId)
-            stmt.setString(3, listing.language.toString())
-            stmt.setString(4, listing.name)
-            stmt.setString(5, listing.shortDescription)
-            stmt.executeSingleUpdate().bind()
         }
     }
 
@@ -1363,11 +1369,11 @@ private fun ResultSet.readAppDraftApiView(): DataStoreResult<AppDraftApiView> = 
 }
 
 /**
- * Reads an [AppDraftListing] from the current row, which must expose every `app_draft_listings`
- * column selected by this repository.
+ * Reads an [AppDraftListingApiView] from the current row, which must expose every
+ * `app_draft_listings` column selected by this repository.
  */
-private fun ResultSet.readAppDraftListing(): DataStoreResult<AppDraftListing> = either {
-    AppDraftListing(
+private fun ResultSet.readAppDraftListingApiView(): DataStoreResult<AppDraftListingApiView> = either {
+    AppDraftListingApiView(
         id = requireString("id").bind(),
         appDraftId = requireString("app_draft_id").bind(),
         language = ListingLanguage.fromString(requireString("language").bind())

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
@@ -91,7 +91,6 @@ import arrow.core.raise.either
 import arrow.core.raise.ensure
 import com.google.protobuf.InvalidProtocolBufferException
 import kotlin.io.encoding.Base64
-import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListing as DataAppDraftListing
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.ListingLanguage as DataListingLanguage
 import app.accrescent.server.parcelo.domain.ports.driving.console.AppDraft as ApiAppDraft
 import app.accrescent.server.parcelo.domain.ports.driving.console.AppDraftListing as ApiAppDraftListing
@@ -467,14 +466,12 @@ class AppDraftApiImpl(
                 .generateId(IdType.APP_DRAFT_LISTING)
                 .bindMapLeft(::toServerError)
             tx.appDrafts
-                .saveListing(
-                    DataAppDraftListing(
-                        id = listingId,
-                        appDraftId = request.appDraftId,
-                        language = dataStoreLanguage,
-                        name = request.name,
-                        shortDescription = request.shortDescription,
-                    )
+                .createListing(
+                    id = listingId,
+                    appDraftId = request.appDraftId,
+                    language = dataStoreLanguage,
+                    name = request.name,
+                    shortDescription = request.shortDescription,
                 )
                 .bindMapLeft(::toServerError)
 
@@ -501,7 +498,9 @@ class AppDraftApiImpl(
             ensure(hasPermission) { InsufficientPermissionError }
 
             // App draft listing is guaranteed to exist since permission is granted
-            tx.appDrafts.requireListingById(request.appDraftListingId).bindMapLeft(::toServerError)
+            tx.appDrafts
+                .requireListingApiViewById(request.appDraftListingId)
+                .bindMapLeft(::toServerError)
         }
             .bindMapLeft(::toServerError)
             .bind()
@@ -550,7 +549,7 @@ class AppDraftApiImpl(
             val userId = authenticateCaller(tx, context.sessionId, timestampSource.now()).bind()
 
             tx.appDrafts
-                .findListingsForAppDraftAndUserByQuery(
+                .findListingApiViewsForAppDraftAndUserByQuery(
                     appDraftId = request.appDraftId,
                     userId = userId,
                     maxResults = maxResults,
@@ -595,7 +594,7 @@ class AppDraftApiImpl(
 
             // App draft listing is guaranteed to exist since permission is granted
             val listing = tx.appDrafts
-                .requireListingById(request.appDraftListingId)
+                .requireListingApiViewById(request.appDraftListingId)
                 .bindMapLeft(::toServerError)
 
             // App draft is guaranteed to exist since permission is granted
@@ -634,7 +633,7 @@ class AppDraftApiImpl(
 
             // App draft listing is guaranteed to exist since permission is granted
             val listing = tx.appDrafts
-                .requireListingById(request.appDraftListingId)
+                .requireListingApiViewById(request.appDraftListingId)
                 .bindMapLeft(::toServerError)
 
             // App draft is guaranteed to exist since permission is granted
@@ -723,7 +722,7 @@ class AppDraftApiImpl(
 
             // App draft listing is guaranteed to exist since permission is granted
             val listing = tx.appDrafts
-                .requireListingById(request.appDraftListingId)
+                .requireListingApiViewById(request.appDraftListingId)
                 .bindMapLeft(::toServerError)
 
             // App draft is guaranteed to exist since permission is granted

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/AppDraftListingApiView.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/AppDraftListingApiView.kt
@@ -5,7 +5,7 @@
 package app.accrescent.server.parcelo.domain.ports.driven.datastore
 
 /**
- * An app store listing for an app in draft stage.
+ * The API view of an app store listing for an app in draft stage.
  *
  * @property id the unique ID of this app draft listing.
  * @property appDraftId the ID of the app draft this listing belongs to.
@@ -13,7 +13,7 @@ package app.accrescent.server.parcelo.domain.ports.driven.datastore
  * @property name the name of the app, limited to 30 characters.
  * @property shortDescription a short description of the app, limited to 80 characters.
  */
-data class AppDraftListing(
+data class AppDraftListingApiView(
     val id: String,
     val appDraftId: String,
     val language: ListingLanguage,

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStore.kt
@@ -175,6 +175,25 @@ abstract class DataStore(private val randomSource: RandomSource) {
         ): DataStoreResult<Unit>
 
         /**
+         * Creates a new app draft listing.
+         *
+         * @param id the ID of the app draft listing to create.
+         * @param appDraftId the ID of the app draft to create this listing for.
+         * @param language the language the new listing's contents are written in.
+         * @param name the name to set for the new listing.
+         * @param shortDescription the short description to set for the new listing.
+         * @return [DataStoreError.ConsistencyViolation] if a listing with the same ID or
+         * (appDraftId, language) pair already exists or the referenced app draft does not exist.
+         */
+        abstract fun createListing(
+            id: String,
+            appDraftId: String,
+            language: ListingLanguage,
+            name: String,
+            shortDescription: String,
+        ): DataStoreResult<Unit>
+
+        /**
          * Deletes an app draft along with its associated data.
          *
          * Because they are part of the app draft, this draft's listings, package, and pending
@@ -268,16 +287,19 @@ abstract class DataStore(private val randomSource: RandomSource) {
         ): DataStoreResult<List<AppDraftApiView>>
 
         /**
-         * Finds an existing app draft listing.
+         * Finds the API view of an existing app draft listing.
          *
          * @param id the ID of the app draft listing to find.
-         * @return the app draft listing with the given ID, or [None] if it doesn't exist.
+         * @return the API view of the app draft listing with the given ID, or [None] if it doesn't
+         * exist.
          */
-        abstract fun findListingById(id: String): DataStoreResult<Option<AppDraftListing>>
+        abstract fun findListingApiViewById(
+            id: String,
+        ): DataStoreResult<Option<AppDraftListingApiView>>
 
         /**
-         * Finds a list of app draft listings for a given app draft which a given user is authorized
-         * to view.
+         * Finds the API views for a list of app draft listings for a given app draft which a given
+         * user is authorized to view.
          *
          * Results are ordered alphabetically by the listing language's BCP-47 code.
          *
@@ -286,14 +308,14 @@ abstract class DataStore(private val randomSource: RandomSource) {
          * @param maxResults the maximum number of app draft listings to retrieve.
          * @param afterLanguage the listing language to start listing after, or [None] to start
          * from the beginning.
-         * @return the list of app draft listings matching the query.
+         * @return the list of app draft listing API views matching the query.
          */
-        abstract fun findListingsForAppDraftAndUserByQuery(
+        abstract fun findListingApiViewsForAppDraftAndUserByQuery(
             appDraftId: String,
             userId: String,
             maxResults: NonNegativeInt,
             afterLanguage: Option<ListingLanguage>,
-        ): DataStoreResult<List<AppDraftListing>>
+        ): DataStoreResult<List<AppDraftListingApiView>>
 
         /**
          * Finds a pending app draft listing icon upload by its target blob's object key.
@@ -402,24 +424,16 @@ abstract class DataStore(private val randomSource: RandomSource) {
         }
 
         /**
-         * Finds an existing app draft listing.
+         * Finds the API view of an existing app draft listing.
          *
          * @param id the ID of the app draft listing to find.
-         * @return the app draft listing with the given ID, or [DataStoreError.EntityNotFound] if it
-         * doesn't exist.
+         * @return the API view of the app draft listing with the given ID, or
+         * [DataStoreError.EntityNotFound] if it doesn't exist.
          */
-        fun requireListingById(id: String): DataStoreResult<AppDraftListing> {
-            return findListingById(id).flatMap { it.toEither { DataStoreError.EntityNotFound } }
+        fun requireListingApiViewById(id: String): DataStoreResult<AppDraftListingApiView> {
+            return findListingApiViewById(id)
+                .flatMap { it.toEither { DataStoreError.EntityNotFound } }
         }
-
-        /**
-         * Saves a new app draft listing.
-         *
-         * @param listing the app draft listing to save.
-         * @return [DataStoreError.ConsistencyViolation] if a listing with the same ID or
-         * (appDraftId, language) pair already exists or the referenced app draft does not exist.
-         */
-        abstract fun saveListing(listing: AppDraftListing): DataStoreResult<Unit>
 
         /**
          * Saves a new pending app draft listing icon upload along with the blob it owns.

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/DataStoreUtils.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/DataStoreUtils.kt
@@ -15,7 +15,7 @@ import app.accrescent.server.parcelo.domain.android.VersionName
 import app.accrescent.server.parcelo.domain.authn.ExternalUserId
 import app.accrescent.server.parcelo.domain.crypto.Sha256Hash
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftApiView
-import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListing
+import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppDraftListingApiView
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppPackage
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.AppPackageApiView
 import app.accrescent.server.parcelo.domain.ports.driven.datastore.DataStore
@@ -31,14 +31,31 @@ import java.time.OffsetDateTime
 
 val UNIX_EPOCH = FixedTimestampSource().now()
 
-fun appDraftListing(
+fun appDraftListingApiView(
     id: String = "appDraftListing1",
     appDraftId: String = "appDraft1",
     language: ListingLanguage = ListingLanguage.EN_US,
     name: String = "Example App",
     shortDescription: String = "Example Short Description",
-): AppDraftListing {
-    return AppDraftListing(
+): AppDraftListingApiView {
+    return AppDraftListingApiView(
+        id = id,
+        appDraftId = appDraftId,
+        language = language,
+        name = name,
+        shortDescription = shortDescription,
+    )
+}
+
+fun createAppDraftListing(
+    tx: DataStore.Transaction,
+    id: String = "appDraftListing1",
+    appDraftId: String = "appDraft1",
+    language: ListingLanguage = ListingLanguage.EN_US,
+    name: String = "Example App",
+    shortDescription: String = "Example Short Description",
+): DataStoreResult<Unit> {
+    return tx.appDrafts.createListing(
         id = id,
         appDraftId = appDraftId,
         language = language,

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImplTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImplTest.kt
@@ -10,8 +10,8 @@ import app.accrescent.server.parcelo.adapters.driven.blobstorage.LocalOnlyBlobSt
 import app.accrescent.server.parcelo.adapters.driven.datastore.jdbc.InMemoryDataStore
 import app.accrescent.server.parcelo.adapters.driven.randomsource.DeterministicRandomSource
 import app.accrescent.server.parcelo.adapters.driven.timestampsource.FixedTimestampSource
-import app.accrescent.server.parcelo.appDraftListing
 import app.accrescent.server.parcelo.appPackage
+import app.accrescent.server.parcelo.createAppDraftListing
 import app.accrescent.server.parcelo.core.unwrap
 import app.accrescent.server.parcelo.core.unwrap2
 import app.accrescent.server.parcelo.core.unwrapErr
@@ -221,7 +221,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -290,7 +290,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -418,7 +418,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }.unwrap2()
@@ -481,7 +481,7 @@ class AppDraftApiImplTest {
                     objectKey = "object1",
                 )
                     .bind()
-                tx.appDrafts.saveListing(appDraftListing("appDraftListing2", "appDraft2")).bind()
+                createAppDraftListing(tx, "appDraftListing2", "appDraft2").bind()
                 tx.appDrafts.updateDefaultListing("appDraft2", Some("appDraftListing2")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft2", UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
@@ -496,7 +496,7 @@ class AppDraftApiImplTest {
                     objectKey = "object2",
                 )
                     .bind()
-                tx.appDrafts.saveListing(appDraftListing("appDraftListing1", "appDraft1")).bind()
+                createAppDraftListing(tx, "appDraftListing1", "appDraft1").bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }.unwrap2()
             val appDraftApi = makeAppDraftApi(dataStore)
@@ -516,7 +516,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.apps.saveWithDefaultListing(
                     App("app1", "org1", "appListing1", false),
@@ -540,7 +540,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap2()
@@ -580,7 +580,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -647,7 +647,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -724,7 +724,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -804,7 +804,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -947,7 +947,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -1019,7 +1019,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -1104,7 +1104,7 @@ class AppDraftApiImplTest {
                 signInNewUser(tx).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", FixedTimestampSource().now()).bind()
             }

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/async/UploadEventProcessorImplTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/async/UploadEventProcessorImplTest.kt
@@ -12,8 +12,8 @@ import app.accrescent.server.parcelo.adapters.driven.datastore.jdbc.InMemoryData
 import app.accrescent.server.parcelo.adapters.driven.file.LocalTempFile
 import app.accrescent.server.parcelo.adapters.driven.randomsource.DeterministicRandomSource
 import app.accrescent.server.parcelo.adapters.driven.timestampsource.FixedTimestampSource
-import app.accrescent.server.parcelo.appDraftListing
 import app.accrescent.server.parcelo.appPackage
+import app.accrescent.server.parcelo.createAppDraftListing
 import app.accrescent.server.parcelo.core.Bytes
 import app.accrescent.server.parcelo.core.unwrap
 import app.accrescent.server.parcelo.core.unwrap2
@@ -211,7 +211,7 @@ class UploadEventProcessorImplTest {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                     saveAppPackageFromNewUpload(tx).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                     tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                     tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
                     tx.appDrafts.deletePendingUploadByAppDraftId("appDraft1", UNIX_EPOCH).bind()

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreConformanceTest.kt
@@ -5,8 +5,9 @@
 package app.accrescent.server.parcelo.domain.ports.driven.datastore
 
 import app.accrescent.server.parcelo.UNIX_EPOCH
-import app.accrescent.server.parcelo.appDraftListing
+import app.accrescent.server.parcelo.appDraftListingApiView
 import app.accrescent.server.parcelo.appPackage
+import app.accrescent.server.parcelo.createAppDraftListing
 import app.accrescent.server.parcelo.core.NonNegativeInt
 import app.accrescent.server.parcelo.core.unwrap
 import app.accrescent.server.parcelo.core.unwrap2
@@ -222,6 +223,56 @@ abstract class DataStoreConformanceTest {
     }
 
     @Test
+    fun `appDrafts createListing returns ConsistencyViolationError for duplicate ID`() {
+        withMigratedDataStore { dataStore ->
+            dataStore.runTxWithRetry { tx ->
+                tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
+                tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
+                createAppDraftListing(tx).bind()
+            }
+                .unwrap2()
+
+            val result = dataStore
+                .runTxWithRetry { tx -> createAppDraftListing(tx).bind() }
+                .unwrap()
+
+            assertEquals(DataStoreError.ConsistencyViolation, result.unwrapErr())
+        }
+    }
+
+    @Test
+    fun `appDrafts createListing returns ConsistencyViolationError for duplicate (appDraftId, language) pair`() {
+        withMigratedDataStore { dataStore ->
+            dataStore.runTxWithRetry { tx ->
+                tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
+                tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
+                createAppDraftListing(tx, "appDraftListing1", "appDraft1", ListingLanguage.EN_US).bind()
+            }
+                .unwrap2()
+
+            val result = dataStore
+                .runTxWithRetry { tx ->
+                    createAppDraftListing(tx, "appDraftListing2", "appDraft1", ListingLanguage.EN_US)
+                        .bind()
+                }
+                .unwrap()
+
+            assertEquals(DataStoreError.ConsistencyViolation, result.unwrapErr())
+        }
+    }
+
+    @Test
+    fun `appDrafts createListing returns ConsistencyViolationError when app draft does not exist`() {
+        withMigratedDataStore { dataStore ->
+            val result = dataStore
+                .runTxWithRetry { tx -> createAppDraftListing(tx).bind() }
+                .unwrap()
+
+            assertEquals(DataStoreError.ConsistencyViolation, result.unwrapErr())
+        }
+    }
+
+    @Test
     fun `appDrafts deleteById returns EntityNotFound for non-existent app draft`() {
         withMigratedDataStore { dataStore ->
             val result = dataStore
@@ -258,7 +309,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }
                 .unwrap2()
 
@@ -312,12 +363,12 @@ abstract class DataStoreConformanceTest {
     }
 
     @Test
-    fun `appDrafts deleteListingById makes findListingById return None`() {
+    fun `appDrafts deleteListingById makes findListingApiViewById return None`() {
         withMigratedDataStore { dataStore ->
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }
                 .unwrap2()
 
@@ -325,7 +376,7 @@ abstract class DataStoreConformanceTest {
                 .runTxWithRetry { tx -> tx.appDrafts.deleteListingById("appDraftListing1", UNIX_EPOCH).bind() }
                 .unwrap2()
             val listing = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.findListingById("appDraftListing1").bind() }
+                .runTxWithRetry { tx -> tx.appDrafts.findListingApiViewById("appDraftListing1").bind() }
                 .unwrap2()
 
             assertTrue(listing.isNone())
@@ -352,7 +403,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.saveListingIconUpload(
                     incompletePendingAppDraftListingIconUpload(),
                     pendingExternalBlob(),
@@ -435,7 +486,7 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx, originalAppPackage).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }
@@ -497,7 +548,7 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx, originalAppPackage).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }.unwrap2()
@@ -632,10 +683,10 @@ abstract class DataStoreConformanceTest {
     }
 
     @Test
-    fun `appDrafts findListingById returns None when no listing with the given ID exists`() {
+    fun `appDrafts findListingApiViewById returns None when no listing with the given ID exists`() {
         withMigratedDataStore { dataStore ->
             val result = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.findListingById("appDraftListing1").bind() }
+                .runTxWithRetry { tx -> tx.appDrafts.findListingApiViewById("appDraftListing1").bind() }
                 .unwrap2()
 
             assertTrue(result.isNone())
@@ -669,24 +720,20 @@ abstract class DataStoreConformanceTest {
     }
 
     @Test
-    fun `appDrafts findListingsForAppDraftAndUserByQuery returns listings for only requested app draft`() {
+    fun `appDrafts findListingApiViewsForAppDraftAndUserByQuery returns listings for only requested app draft`() {
         withMigratedDataStore { dataStore ->
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft2", UNIX_EPOCH).bind()
-                tx.appDrafts
-                    .saveListing(appDraftListing(id = "appDraftListing1", appDraftId = "appDraft1"))
-                    .bind()
-                tx.appDrafts
-                    .saveListing(appDraftListing(id = "appDraftListing2", appDraftId = "appDraft2"))
-                    .bind()
+                createAppDraftListing(tx, "appDraftListing1", "appDraft1").bind()
+                createAppDraftListing(tx, "appDraftListing2", "appDraft2").bind()
             }.unwrap2()
 
             val listings = dataStore
                 .runTxWithRetry { tx ->
                     tx.appDrafts
-                        .findListingsForAppDraftAndUserByQuery(
+                        .findListingApiViewsForAppDraftAndUserByQuery(
                             appDraftId = "appDraft1",
                             userId = "user1",
                             maxResults = NonNegativeInt.new(2).unwrap(),
@@ -697,26 +744,26 @@ abstract class DataStoreConformanceTest {
                 .unwrap2()
 
             assertEquals(
-                listOf(appDraftListing(id = "appDraftListing1", appDraftId = "appDraft1")),
+                listOf(appDraftListingApiView(id = "appDraftListing1", appDraftId = "appDraft1")),
                 listings,
             )
         }
     }
 
     @Test
-    fun `appDrafts findListingsForAppDraftAndUserByQuery returns only authorized listings`() {
+    fun `appDrafts findListingApiViewsForAppDraftAndUserByQuery returns only authorized listings`() {
         withMigratedDataStore { dataStore ->
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.organizations.saveWithOwner("org2", "user2", ExternalUserId.Github(2), UNIX_EPOCH).bind()
             }.unwrap2()
 
             val listings = dataStore
                 .runTxWithRetry { tx ->
                     tx.appDrafts
-                        .findListingsForAppDraftAndUserByQuery(
+                        .findListingApiViewsForAppDraftAndUserByQuery(
                             appDraftId = "appDraft1",
                             userId = "user2",
                             maxResults = NonNegativeInt.new(1).unwrap(),
@@ -726,7 +773,7 @@ abstract class DataStoreConformanceTest {
                 }
                 .unwrap2()
 
-            assertEquals(emptyList<AppDraftListing>(), listings)
+            assertEquals(emptyList<AppDraftListingApiView>(), listings)
         }
     }
 
@@ -764,7 +811,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }.unwrap2()
 
@@ -811,7 +858,7 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx, appPackage()).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
                 tx.appDrafts.updateSubmitTime("appDraft1", UNIX_EPOCH).bind()
             }.unwrap2()
@@ -844,7 +891,7 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft2", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing("appDraftListing1", "appDraft1")).bind()
+                createAppDraftListing(tx, "appDraftListing1", "appDraft1").bind()
             }.unwrap2()
 
             val exists = dataStore
@@ -863,7 +910,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }.unwrap2()
 
             val exists = dataStore
@@ -882,7 +929,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }.unwrap2()
 
             val exists = dataStore
@@ -915,7 +962,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }
                 .unwrap2()
 
@@ -947,7 +994,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }.unwrap2()
 
             val isDefault = dataStore
@@ -964,7 +1011,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }.unwrap2()
 
@@ -995,7 +1042,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.saveListingIconUpload(
                     incompletePendingAppDraftListingIconUpload(),
                     pendingExternalBlob(),
@@ -1042,92 +1089,14 @@ abstract class DataStoreConformanceTest {
     }
 
     @Test
-    fun `appDrafts saveListing returns ConsistencyViolationError for duplicate ID`() {
-        withMigratedDataStore { dataStore ->
-            dataStore.runTxWithRetry { tx ->
-                tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
-                tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
-            }
-                .unwrap2()
-
-            val result = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.saveListing(appDraftListing()).bind() }
-                .unwrap()
-
-            assertEquals(DataStoreError.ConsistencyViolation, result.unwrapErr())
-        }
-    }
-
-    @Test
-    fun `appDrafts saveListing returns ConsistencyViolationError for duplicate (appDraftId, language) pair`() {
-        withMigratedDataStore { dataStore ->
-            dataStore.runTxWithRetry { tx ->
-                tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
-                tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts
-                    .saveListing(appDraftListing("appDraftListing1", "appDraft1", ListingLanguage.EN_US))
-                    .bind()
-            }
-                .unwrap2()
-
-            val result = dataStore.runTxWithRetry { tx ->
-                tx.appDrafts
-                    .saveListing(appDraftListing("appDraftListing2", "appDraft1", ListingLanguage.EN_US))
-                    .bind()
-            }
-                .unwrap()
-
-            assertEquals(DataStoreError.ConsistencyViolation, result.unwrapErr())
-        }
-    }
-
-    @Test
-    fun `appDrafts saveListing returns ConsistencyViolationError when app draft does not exist`() {
-        withMigratedDataStore { dataStore ->
-
-            val result = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.saveListing(appDraftListing()).bind() }
-                .unwrap()
-
-            assertEquals(DataStoreError.ConsistencyViolation, result.unwrapErr())
-        }
-    }
-
-    @Test
-    fun `appDrafts saveListing and findListingById round-trip data`() {
-        withMigratedDataStore { dataStore ->
-            val originalListing = appDraftListing()
-            dataStore.runTxWithRetry { tx ->
-                tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
-                tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-            }
-                .unwrap2()
-
-            dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.saveListing(originalListing).bind() }
-                .unwrap2()
-            val foundListing = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.findListingById(originalListing.id).bind() }
-                .unwrap2()
-
-            assertEquals(Some(originalListing), foundListing)
-        }
-    }
-
-    @Test
     fun `appDrafts saveListingIconUpload returns ConsistencyViolationError for duplicate ID`() {
         withMigratedDataStore { dataStore ->
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft2", UNIX_EPOCH).bind()
-                tx.appDrafts
-                    .saveListing(appDraftListing(id = "appDraftListing1", appDraftId = "appDraft1"))
-                    .bind()
-                tx.appDrafts
-                    .saveListing(appDraftListing(id = "appDraftListing2", appDraftId = "appDraft2"))
-                    .bind()
+                createAppDraftListing(tx, "appDraftListing1", "appDraft1").bind()
+                createAppDraftListing(tx, "appDraftListing2", "appDraft2").bind()
                 tx.appDrafts.saveListingIconUpload(
                     incompletePendingAppDraftListingIconUpload(
                         appDraftListingId = "appDraftListing1",
@@ -1160,7 +1129,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.saveListingIconUpload(
                     incompletePendingAppDraftListingIconUpload(),
                     pendingExternalBlob(),
@@ -1192,12 +1161,8 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft2", UNIX_EPOCH).bind()
-                tx.appDrafts
-                    .saveListing(appDraftListing(id = "appDraftListing1", appDraftId = "appDraft1"))
-                    .bind()
-                tx.appDrafts
-                    .saveListing(appDraftListing(id = "appDraftListing2", appDraftId = "appDraft2"))
-                    .bind()
+                createAppDraftListing(tx, "appDraftListing1", "appDraft1").bind()
+                createAppDraftListing(tx, "appDraftListing2", "appDraft2").bind()
                 tx.appDrafts
                     .saveListingIconUpload(
                         incompletePendingAppDraftListingIconUpload(objectKey = "object1"),
@@ -1249,7 +1214,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.saveListingIconUpload(originalUpload, pendingExternalBlob()).bind()
             }.unwrap2()
             val foundUpload = dataStore
@@ -1419,7 +1384,7 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft2", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }
                 .unwrap2()
 
@@ -1451,7 +1416,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }
                 .unwrap2()
 
@@ -1476,7 +1441,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap2()
@@ -1511,11 +1476,10 @@ abstract class DataStoreConformanceTest {
     @Test
     fun `appDrafts updateListing leaves null fields unchanged`() {
         withMigratedDataStore { dataStore ->
-            val originalListing = appDraftListing()
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(originalListing).bind()
+                createAppDraftListing(tx).bind()
             }
                 .unwrap2()
 
@@ -1524,10 +1488,10 @@ abstract class DataStoreConformanceTest {
             }
                 .unwrap2()
             val foundListing = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.findListingById(originalListing.id).bind() }
+                .runTxWithRetry { tx -> tx.appDrafts.findListingApiViewById("appDraftListing1").bind() }
                 .unwrap2()
 
-            assertEquals(Some(originalListing), foundListing)
+            assertEquals(Some(appDraftListingApiView()), foundListing)
         }
     }
 
@@ -1537,7 +1501,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
             }
                 .unwrap2()
 
@@ -1552,7 +1516,7 @@ abstract class DataStoreConformanceTest {
             }
                 .unwrap2()
             val foundListing = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.findListingById("appDraftListing1").bind() }
+                .runTxWithRetry { tx -> tx.appDrafts.findListingApiViewById("appDraftListing1").bind() }
                 .unwrap2()
                 .unwrap()
 
@@ -1654,7 +1618,7 @@ abstract class DataStoreConformanceTest {
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 saveAppPackageFromNewUpload(tx).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap2()
@@ -1678,7 +1642,7 @@ abstract class DataStoreConformanceTest {
             dataStore.runTxWithRetry { tx ->
                 tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                 tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                tx.appDrafts.saveListing(appDraftListing()).bind()
+                createAppDraftListing(tx).bind()
                 tx.appDrafts.updateDefaultListing("appDraft1", Some("appDraftListing1")).bind()
             }
                 .unwrap2()
@@ -2340,7 +2304,7 @@ abstract class DataStoreConformanceTest {
                 .runTxWithRetry { tx ->
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                     tx.appDrafts
                         .saveListingIconUpload(
                             incompletePendingAppDraftListingIconUpload(),
@@ -2368,7 +2332,7 @@ abstract class DataStoreConformanceTest {
                 .runTxWithRetry { tx ->
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                     tx.appDrafts
                         .saveListingIconUpload(
                             incompletePendingAppDraftListingIconUpload(),
@@ -2400,7 +2364,7 @@ abstract class DataStoreConformanceTest {
                 .runTxWithRetry { tx ->
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                     tx.appDrafts
                         .saveListingIconUpload(
                             incompletePendingAppDraftListingIconUpload(),
@@ -2992,7 +2956,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing(id = invalid)).bind()
+                    createAppDraftListing(tx, id = invalid).bind()
                 }
             },
             TextColumnConstraintTestCase("appListings.id") { tx, invalid ->
@@ -3032,7 +2996,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                     tx.appDrafts
                         .saveListingIconUpload(
                             incompletePendingAppDraftListingIconUpload(id = invalid),
@@ -3054,7 +3018,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing(name = tooLong)).bind()
+                    createAppDraftListing(tx, name = tooLong).bind()
                 }
             },
             TextLengthConstraintTestCase(
@@ -3064,7 +3028,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing(shortDescription = tooLong)).bind()
+                    createAppDraftListing(tx, shortDescription = tooLong).bind()
                 }
             },
         )
@@ -3084,14 +3048,14 @@ abstract class DataStoreConformanceTest {
                     either {
                         tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                         tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                        tx.appDrafts.saveListing(appDraftListing(name = invalid)).bind()
+                        createAppDraftListing(tx, name = invalid).bind()
                     }
                 },
                 TextColumnConstraintTestCase("appDraftListings.shortDescription") { tx, invalid ->
                     either {
                         tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                         tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                        tx.appDrafts.saveListing(appDraftListing(shortDescription = invalid)).bind()
+                        createAppDraftListing(tx, shortDescription = invalid).bind()
                     }
                 },
                 TextColumnConstraintTestCase("appPackages.versionName") { tx, invalid ->
@@ -3294,7 +3258,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                 }
             },
             AuthzHasPermissionReturnsTrueWithMinimalRelationships(
@@ -3346,7 +3310,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                 }
             },
             AuthzHasPermissionReturnsTrueWithMinimalRelationships(
@@ -3355,7 +3319,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                 }
             },
             AuthzHasPermissionReturnsTrueWithMinimalRelationships(
@@ -3383,7 +3347,7 @@ abstract class DataStoreConformanceTest {
                 either {
                     tx.organizations.saveWithOwner("org1", "user1", ExternalUserId.Github(1), UNIX_EPOCH).bind()
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
-                    tx.appDrafts.saveListing(appDraftListing()).bind()
+                    createAppDraftListing(tx).bind()
                 }
             },
         )

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/ports/driven/datastore/DataStoreTest.kt
@@ -7,8 +7,9 @@ package app.accrescent.server.parcelo.domain.ports.driven.datastore
 import app.accrescent.server.parcelo.UNIX_EPOCH
 import app.accrescent.server.parcelo.adapters.driven.datastore.jdbc.InMemoryDataStore
 import app.accrescent.server.parcelo.adapters.driven.randomsource.DeterministicRandomSource
-import app.accrescent.server.parcelo.appDraftListing
+import app.accrescent.server.parcelo.appDraftListingApiView
 import app.accrescent.server.parcelo.committedExternalBlob
+import app.accrescent.server.parcelo.createAppDraftListing
 import app.accrescent.server.parcelo.core.unwrap
 import app.accrescent.server.parcelo.core.unwrap2
 import app.accrescent.server.parcelo.core.unwrapErr
@@ -75,12 +76,12 @@ class DataStoreTest {
     }
 
     @Test
-    fun `appDrafts requireListingById returns EntityNotFound if listing does not exist`() {
+    fun `appDrafts requireListingApiViewById returns EntityNotFound if listing does not exist`() {
         InMemoryDataStore(DeterministicRandomSource()).use { dataStore ->
             dataStore.migrateToHead().unwrap()
 
             val error = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.requireListingById("appDraftListing1").bind() }
+                .runTxWithRetry { tx -> tx.appDrafts.requireListingApiViewById("appDraftListing1").bind() }
                 .unwrap()
                 .unwrapErr()
 
@@ -89,7 +90,7 @@ class DataStoreTest {
     }
 
     @Test
-    fun `appDrafts requireListingById returns app draft listing persisted with save`() {
+    fun `appDrafts requireListingApiViewById returns app draft listing persisted with createListing`() {
         InMemoryDataStore(DeterministicRandomSource()).use { dataStore ->
             dataStore.migrateToHead().unwrap()
             dataStore
@@ -98,14 +99,13 @@ class DataStoreTest {
                     tx.appDrafts.create("org1", "appDraft1", UNIX_EPOCH).bind()
                 }
                 .unwrap2()
-            val originalListing = appDraftListing()
 
-            dataStore.runTxWithRetry { tx -> tx.appDrafts.saveListing(originalListing).bind() }.unwrap2()
+            dataStore.runTxWithRetry { tx -> createAppDraftListing(tx).bind() }.unwrap2()
             val foundListing = dataStore
-                .runTxWithRetry { tx -> tx.appDrafts.requireListingById("appDraftListing1").bind() }
+                .runTxWithRetry { tx -> tx.appDrafts.requireListingApiViewById("appDraftListing1").bind() }
                 .unwrap2()
 
-            assertEquals(originalListing, foundListing)
+            assertEquals(appDraftListingApiView(), foundListing)
         }
     }
 


### PR DESCRIPTION
This change does away with the legacy AppDraftListing DataStore entity and its saveListing() DataStore method and replaces them with AppDraftApiView (for reads directly into an app draft listing API message) and a new method createListing() which has a distinct write model.