### PR TITLE
Replace `intoInner()` functions with public properties

### DIFF
--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
@@ -458,7 +458,7 @@ private class InMemoryAppDraftRepository(
                 )
             """.trimIndent()
             connection.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, appId.intoInner())
+                stmt.setString(1, appId.value)
                 stmt.executeQuery().use { rs -> rs.getSelectExistsResult().bind() }
             }
         }
@@ -965,10 +965,10 @@ private class InMemoryAppPackageRepository(
             stmt.setString(2, appPackage.appDraftId)
             stmt.setString(3, appPackage.externalBlobId)
             stmt.setObject(4, appPackage.uploadEventTime)
-            stmt.setString(5, appPackage.appId.intoInner())
-            stmt.setInt(6, appPackage.versionCode.intoInner())
-            stmt.setString(7, appPackage.versionName.intoInner())
-            stmt.setInt(8, appPackage.targetSdk.intoInner())
+            stmt.setString(5, appPackage.appId.value)
+            stmt.setInt(6, appPackage.versionCode.value)
+            stmt.setString(7, appPackage.versionName.value)
+            stmt.setInt(8, appPackage.targetSdk.value)
             stmt.setBytes(9, appPackage.signerCertificate.value)
             stmt.setBytes(10, appPackage.buildApksResult.value)
             stmt.executeSingleUpdate().bind()
@@ -981,8 +981,8 @@ private class InMemoryAppPackageRepository(
         connection.prepareStatement(insertPermissionSql).use { stmt ->
             for ((name, maxSdkVersion) in permissions) {
                 stmt.setString(1, appPackage.id)
-                stmt.setString(2, name.intoInner())
-                stmt.setObject(3, maxSdkVersion.map(SdkVersion::intoInner).getOrNull(), Types.INTEGER)
+                stmt.setString(2, name.value)
+                stmt.setObject(3, maxSdkVersion.map(SdkVersion::value).getOrNull(), Types.INTEGER)
                 stmt.executeSingleUpdate().bind()
             }
         }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
@@ -396,7 +396,7 @@ private class PostgresqlAppDraftRepository(
                 )
             """.trimIndent()
             connection.prepareStatement(sql).use { stmt ->
-                stmt.setString(1, appId.intoInner())
+                stmt.setString(1, appId.value)
                 stmt.executeQuery().use { rs -> rs.getSelectExistsResult().bind() }
             }
         }
@@ -953,10 +953,10 @@ private class PostgresqlAppPackageRepository(
             stmt.setString(11, appPackage.appDraftId)
             stmt.setString(12, appPackage.externalBlobId)
             stmt.setObject(13, appPackage.uploadEventTime)
-            stmt.setString(14, appPackage.appId.intoInner())
-            stmt.setInt(15, appPackage.versionCode.intoInner())
-            stmt.setString(16, appPackage.versionName.intoInner())
-            stmt.setInt(17, appPackage.targetSdk.intoInner())
+            stmt.setString(14, appPackage.appId.value)
+            stmt.setInt(15, appPackage.versionCode.value)
+            stmt.setString(16, appPackage.versionName.value)
+            stmt.setInt(17, appPackage.targetSdk.value)
             stmt.setBytes(18, appPackage.signerCertificate.value)
             stmt.setBytes(19, appPackage.buildApksResult.value)
             stmt.setString(20, appPackage.id)
@@ -972,10 +972,10 @@ private class PostgresqlAppPackageRepository(
         connection.prepareStatement(permissionSql).use { stmt ->
             for ((name, maxSdkVersion) in permissions) {
                 stmt.setString(1, appPackage.id)
-                stmt.setString(2, name.intoInner())
+                stmt.setString(2, name.value)
                 stmt.setObject(
                     3,
-                    maxSdkVersion.map(SdkVersion::intoInner).getOrNull(),
+                    maxSdkVersion.map(SdkVersion::value).getOrNull(),
                     Types.INTEGER,
                 )
                 stmt.executeSingleUpdate().bind()

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/async/AppDraftUploadedProcessor.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/async/AppDraftUploadedProcessor.kt
@@ -211,7 +211,7 @@ class AppDraftUploadedProcessor @Inject constructor(
             appId = apkSet.applicationId,
             versionCode = apkSet.versionCode,
             versionName = apkSet.versionName,
-            targetSdk = apkSet.targetSdk.intoInner(),
+            targetSdk = apkSet.targetSdk.value,
             signingCertificate = apkSet.signingCert.encoded,
             buildApksResult = apkSet.buildApksResult.toByteArray(),
         )

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/async/AppEditUploadedProcessor.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/async/AppEditUploadedProcessor.kt
@@ -249,7 +249,7 @@ class AppEditUploadedProcessor @Inject constructor(
             appId = apkSet.applicationId,
             versionCode = apkSet.versionCode,
             versionName = apkSet.versionName,
-            targetSdk = apkSet.targetSdk.intoInner(),
+            targetSdk = apkSet.targetSdk.value,
             signingCertificate = apkSet.signingCert.encoded,
             buildApksResult = apkSet.buildApksResult.toByteArray(),
         )

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/core/NonEmptyString.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/core/NonEmptyString.kt
@@ -10,9 +10,11 @@ import arrow.core.Some
 
 /**
  * A character string containing at least one character.
+ *
+ * @property value the string representation of this non-empty string.
  */
 @JvmInline
-value class NonEmptyString private constructor(private val value: String) {
+value class NonEmptyString private constructor(val value: String) {
     companion object {
         /**
          * Creates a non-empty string from a string.
@@ -27,14 +29,5 @@ value class NonEmptyString private constructor(private val value: String) {
                 None
             }
         }
-    }
-
-    /**
-     * Retrieves this non-empty string's underlying string representation.
-     *
-     * @return the string representation of this non-empty string.
-     */
-    fun intoInner(): String {
-        return value
     }
 }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/ApplicationId.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/ApplicationId.kt
@@ -20,9 +20,11 @@ import arrow.core.Some
  *
  * In addition to Android's rules, this class also verifies that the application ID is 128
  * characters long or less to ensure an app with that ID is installable.
+ *
+ * @property value the string representation of this application ID.
  */
 @JvmInline
-value class ApplicationId private constructor(private val value: String) {
+value class ApplicationId private constructor(val value: String) {
     companion object {
         private val REGEX = Regex("""[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+""")
 
@@ -42,14 +44,5 @@ value class ApplicationId private constructor(private val value: String) {
                 None
             }
         }
-    }
-
-    /**
-     * Retrieves this application ID's underlying string representation.
-     *
-     * @return the string representation of this application ID.
-     */
-    fun intoInner(): String {
-        return value
     }
 }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/NameAttribute.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/NameAttribute.kt
@@ -16,9 +16,11 @@ import arrow.core.Some
  * [limited to 1024 characters](https://developer.android.com/guide/topics/manifest/manifest-intro#limits),
  * which this class interprets to mean Unicode code points in accordance with
  * [AIP 210](https://google.aip.dev/210#character-definition).
+ *
+ * @property value the string representation of this name attribute.
  */
 @JvmInline
-value class NameAttribute private constructor(private val value: String) {
+value class NameAttribute private constructor(val value: String) {
     companion object {
         private const val MAX_LENGTH = 1024
 
@@ -36,14 +38,5 @@ value class NameAttribute private constructor(private val value: String) {
                 None
             }
         }
-    }
-
-    /**
-     * Retrieves this name attribute's underlying string representation.
-     *
-     * @return the string representation of this name attribute.
-     */
-    fun intoInner(): String {
-        return value
     }
 }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/SdkVersion.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/SdkVersion.kt
@@ -12,9 +12,11 @@ import arrow.core.Some
  * An Android
  * [SDK version](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels),
  * also known as an API level.
+ *
+ * @property value the integer representation of this SDK version.
  */
 @JvmInline
-value class SdkVersion private constructor(private val value: Int) : Comparable<SdkVersion> {
+value class SdkVersion private constructor(val value: Int) : Comparable<SdkVersion> {
     companion object {
         val MINIMUM = SdkVersion(1)
 
@@ -32,15 +34,6 @@ value class SdkVersion private constructor(private val value: Int) : Comparable<
                 None
             }
         }
-    }
-
-    /**
-     * Retrieves this SDK version's underlying integer representation.
-     *
-     * @return the integer representation of this SDK version.
-     */
-    fun intoInner(): Int {
-        return value
     }
 
     override fun compareTo(other: SdkVersion): Int {

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/VersionCode.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/VersionCode.kt
@@ -35,9 +35,11 @@ import arrow.core.Some
  * different versioning strategy per-store to work around this limitation, but it's much simpler to
  * limit app versions to the same range as Play for now for maximum compatibility with minimal
  * developer friction.
+ *
+ * @property value the integer representation of this version code.
  */
 @JvmInline
-value class VersionCode private constructor(private val value: Int) {
+value class VersionCode private constructor(val value: Int) {
     companion object {
         /**
          * Creates a version code from an integer.
@@ -53,14 +55,5 @@ value class VersionCode private constructor(private val value: Int) {
                 None
             }
         }
-    }
-
-    /**
-     * Retrieves this version code's underlying integer representation.
-     *
-     * @return the integer representation of this version code.
-     */
-    fun intoInner(): Int {
-        return value
     }
 }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/VersionName.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/VersionName.kt
@@ -16,9 +16,11 @@ import arrow.core.Some
  * [limited to 1024 characters](https://developer.android.com/guide/topics/manifest/manifest-intro#limits),
  * which this class interprets to mean Unicode code points in accordance with
  * [AIP 210](https://google.aip.dev/210#character-definition).
+ *
+ * @property value the string representation of this version name.
  */
 @JvmInline
-value class VersionName private constructor(private val value: String) {
+value class VersionName private constructor(val value: String) {
     companion object {
         private const val MAX_LENGTH = 1024
 
@@ -36,14 +38,5 @@ value class VersionName private constructor(private val value: String) {
                 None
             }
         }
-    }
-
-    /**
-     * Retrieves this version name's underlying string representation.
-     *
-     * @return the string representation of this version name.
-     */
-    fun intoInner(): String {
-        return value
     }
 }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/xml/AsciiNcName.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/xml/AsciiNcName.kt
@@ -11,9 +11,11 @@ import arrow.core.Some
 /**
  * An XML [NCName](https://www.w3.org/TR/2009/REC-xml-names-20091208/#NT-NCName) restricted to ASCII
  * characters.
+ *
+ * @property value the string representation of this ASCII NCName.
  */
 @JvmInline
-value class AsciiNcName private constructor(private val value: String) {
+value class AsciiNcName private constructor(val value: String) {
     companion object {
         private val REGEX = Regex("""[A-Za-z_][A-Za-z0-9_.-]*""")
 
@@ -31,14 +33,5 @@ value class AsciiNcName private constructor(private val value: String) {
                 None
             }
         }
-    }
-
-    /**
-     * Retrieves this ASCII NCName's underlying string representation.
-     *
-     * @return the string representation of this ASCII NCName.
-     */
-    fun intoInner(): String {
-        return value
     }
 }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/xml/XmlDocument.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/android/xml/XmlDocument.kt
@@ -198,10 +198,10 @@ data class XmlDocument(val root: XmlElement) {
         ): Either<FromBytesError, XmlExpandedName> = either {
             XmlExpandedName(
                 namespaceName = namespace.map {
-                    Uri.fromString(it.intoInner()).toEitherBind { FromBytesError }
+                    Uri.fromString(it.value).toEitherBind { FromBytesError }
                 },
                 localName = AsciiNcName
-                    .fromString(localName.intoInner())
+                    .fromString(localName.value)
                     .toEitherBind { FromBytesError },
             )
         }

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/domain/api/console/AppDraftApiImpl.kt
@@ -392,7 +392,7 @@ class AppDraftApiImpl(
                 .existsSubmittedForAppId(appId)
                 .bindMapLeft(::toServerError)
             ensure(!appDraftSubmittedForAppId) {
-                AppDraftSubmittedForAppIdError(appId.intoInner())
+                AppDraftSubmittedForAppIdError(appId.value)
             }
 
             val publishedAppCount = tx.apps

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/core/NonEmptyStringTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/core/NonEmptyStringTest.kt
@@ -24,11 +24,11 @@ class NonEmptyStringTest {
     }
 
     @Test
-    fun `intoInner returns original string`() {
+    fun `value returns original string`() {
         val rawString = "Hello, world!"
         val nonEmptyString = NonEmptyString.fromString(rawString).unwrap()
 
-        assertEquals(rawString, nonEmptyString.intoInner())
+        assertEquals(rawString, nonEmptyString.value)
     }
 
     @Test

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/AndroidManifestTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/AndroidManifestTest.kt
@@ -256,7 +256,7 @@ class AndroidManifestTest {
 
         val manifest = AndroidManifest.fromXmlDocument(document).unwrap()
 
-        assertEquals(1, manifest.minSdkVersion.intoInner())
+        assertEquals(1, manifest.minSdkVersion.value)
     }
 
     @Test
@@ -283,7 +283,7 @@ class AndroidManifestTest {
 
         val manifest = AndroidManifest.fromXmlDocument(document).unwrap()
 
-        assertEquals(1, manifest.minSdkVersion.intoInner())
+        assertEquals(1, manifest.minSdkVersion.value)
     }
 
     @Test
@@ -310,7 +310,7 @@ class AndroidManifestTest {
 
         val manifest = AndroidManifest.fromXmlDocument(document).unwrap()
 
-        assertEquals(manifest.minSdkVersion.intoInner(), manifest.targetSdkVersion.intoInner())
+        assertEquals(manifest.minSdkVersion.value, manifest.targetSdkVersion.value)
     }
 
     @Test

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/ApplicationIdTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/ApplicationIdTest.kt
@@ -53,11 +53,11 @@ class ApplicationIdTest {
     }
 
     @Test
-    fun `intoInner returns original string`() {
+    fun `value returns original string`() {
         val rawId = "com.example.myapp"
         val appId = ApplicationId.fromString(rawId).unwrap()
 
-        assertEquals(rawId, appId.intoInner())
+        assertEquals(rawId, appId.value)
     }
 
     @Test

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/NameAttributeTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/NameAttributeTest.kt
@@ -44,11 +44,11 @@ class NameAttributeTest {
     }
 
     @Test
-    fun `intoInner returns original string`() {
+    fun `value returns original string`() {
         val rawName = "android.permission.INTERNET"
         val versionName = NameAttribute.fromString(rawName).unwrap()
 
-        assertEquals(rawName, versionName.intoInner())
+        assertEquals(rawName, versionName.value)
     }
 
     @Test

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/SdkVersionTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/SdkVersionTest.kt
@@ -32,11 +32,11 @@ class SdkVersionTest {
     }
 
     @Test
-    fun `fromInt and intoInner round-trip data`() {
+    fun `fromInt and value round-trip data`() {
         val rawValue = 24
         val sdkVersion = SdkVersion.fromInt(rawValue).unwrap()
 
-        assertEquals(rawValue, sdkVersion.intoInner())
+        assertEquals(rawValue, sdkVersion.value)
     }
 
     @Test

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/VersionCodeTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/VersionCodeTest.kt
@@ -39,11 +39,11 @@ class VersionCodeTest {
     }
 
     @Test
-    fun `fromInt and intoInner round-trip data`() {
+    fun `fromInt and value round-trip data`() {
         val rawCode = 1478417331 // randomly generated
         val versionCode = VersionCode.fromInt(rawCode).unwrap()
 
-        assertEquals(rawCode, versionCode.intoInner())
+        assertEquals(rawCode, versionCode.value)
     }
 
     @Test

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/VersionNameTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/VersionNameTest.kt
@@ -44,11 +44,11 @@ class VersionNameTest {
     }
 
     @Test
-    fun `intoInner returns original string`() {
+    fun `value returns original string`() {
         val rawName = "1.0.0"
         val versionName = VersionName.fromString(rawName).unwrap()
 
-        assertEquals(rawName, versionName.intoInner())
+        assertEquals(rawName, versionName.value)
     }
 
     @Test

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/xml/AsciiNcNameTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/xml/AsciiNcNameTest.kt
@@ -33,11 +33,11 @@ class AsciiNcNameTest {
     }
 
     @Test
-    fun `intoInner returns original string`() {
+    fun `value returns original string`() {
         val rawName = "example-name"
         val name = AsciiNcName.fromString(rawName).unwrap()
 
-        assertEquals(rawName, name.intoInner())
+        assertEquals(rawName, name.value)
     }
 
     @Test


### PR DESCRIPTION
This approach is simpler, more idiomatic for Kotlin, consistent, and less code.