### PR TITLE
Make `Bytes` immutable

### DIFF
--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/InMemoryDataStore.kt
@@ -969,8 +969,8 @@ private class InMemoryAppPackageRepository(
             stmt.setInt(6, appPackage.versionCode.value)
             stmt.setString(7, appPackage.versionName.value)
             stmt.setInt(8, appPackage.targetSdk.value)
-            stmt.setBytes(9, appPackage.signerCertificate.value)
-            stmt.setBytes(10, appPackage.buildApksResult.value)
+            stmt.setBytes(9, appPackage.signerCertificate.copyToByteArray())
+            stmt.setBytes(10, appPackage.buildApksResult.copyToByteArray())
             stmt.executeSingleUpdate().bind()
         }
 
@@ -1413,7 +1413,7 @@ private class InMemorySessionRepository(
             INSERT INTO sessions (id_hash, user_id, create_time, expire_time) VALUES (?, ?, ?, ?)
         """.trimIndent()
         connection.prepareStatement(sql).use { stmt ->
-            stmt.setBytes(1, idHash.digest().value)
+            stmt.setBytes(1, idHash.digest().copyToByteArray())
             stmt.setString(2, userId)
             stmt.setObject(3, createTime)
             stmt.setObject(4, expireTime)
@@ -1449,7 +1449,7 @@ private class InMemoryUserRepository(
     ): DataStoreResult<Option<String>> = runCatchingSql {
         val sql = "SELECT user_id FROM sessions WHERE id_hash = ? AND expire_time > ?"
         connection.prepareStatement(sql).use { stmt ->
-            stmt.setBytes(1, sessionIdHash.digest().value)
+            stmt.setBytes(1, sessionIdHash.digest().copyToByteArray())
             stmt.setObject(2, currentTime)
             stmt.executeQuery().use { rs ->
                 if (!rs.next()) return@use None

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/adapters/driven/datastore/jdbc/PostgresqlDataStore.kt
@@ -957,8 +957,8 @@ private class PostgresqlAppPackageRepository(
             stmt.setInt(15, appPackage.versionCode.value)
             stmt.setString(16, appPackage.versionName.value)
             stmt.setInt(17, appPackage.targetSdk.value)
-            stmt.setBytes(18, appPackage.signerCertificate.value)
-            stmt.setBytes(19, appPackage.buildApksResult.value)
+            stmt.setBytes(18, appPackage.signerCertificate.copyToByteArray())
+            stmt.setBytes(19, appPackage.buildApksResult.copyToByteArray())
             stmt.setString(20, appPackage.id)
             stmt.setString(21, appPackage.appDraftId)
             stmt.setString(22, pendingUploadId)
@@ -1281,7 +1281,7 @@ private class PostgresqlSessionRepository(
             INSERT INTO sessions (id_hash, user_id, create_time, expire_time) VALUES (?, ?, ?, ?)
         """.trimIndent()
         connection.prepareStatement(sql).use { stmt ->
-            stmt.setBytes(1, idHash.digest().value)
+            stmt.setBytes(1, idHash.digest().copyToByteArray())
             stmt.setString(2, userId)
             stmt.setObject(3, createTime)
             stmt.setObject(4, expireTime)
@@ -1317,7 +1317,7 @@ private class PostgresqlUserRepository(
     ): DataStoreResult<Option<String>> = runCatchingSql {
         val sql = "SELECT user_id FROM sessions WHERE id_hash = ? AND expire_time > ?"
         connection.prepareStatement(sql).use { stmt ->
-            stmt.setBytes(1, sessionIdHash.digest().value)
+            stmt.setBytes(1, sessionIdHash.digest().copyToByteArray())
             stmt.setObject(2, currentTime)
             stmt.executeQuery().use { rs ->
                 if (!rs.next()) return@use None

--- a/parcelo/src/main/kotlin/app/accrescent/server/parcelo/core/Bytes.kt
+++ b/parcelo/src/main/kotlin/app/accrescent/server/parcelo/core/Bytes.kt
@@ -5,7 +5,7 @@
 package app.accrescent.server.parcelo.core
 
 /**
- * A [ByteArray] wrapper with structural equality.
+ * An immutable [ByteArray] wrapper with structural equality.
  *
  * The [equals] and [hashCode] implementations for [ByteArray] are instance-based, not
  * content-based, meaning that two [ByteArray]s with the same contents are not considered equal.
@@ -15,9 +15,21 @@ package app.accrescent.server.parcelo.core
  * This class is usable in place of [ByteArray] where structural equality is desired, such as in
  * data classes.
  *
- * @property value the underlying byte array.
+ * [ByteArray]s are also normally mutable. This class performs defensive copies on construction and
+ * [copyToByteArray] conversion to prevent internal mutation.
  */
-class Bytes(val value: ByteArray) {
+class Bytes(value: ByteArray) {
+    private val value: ByteArray = value.copyOf()
+
+    /**
+     * Copies this object's bytes into a new byte array.
+     *
+     * @return a copy of this object's bytes
+     */
+    fun copyToByteArray(): ByteArray {
+        return value.copyOf()
+    }
+
     override fun equals(other: Any?): Boolean {
         return other is Bytes && value.contentEquals(other.value)
     }

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/core/BytesTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/core/BytesTest.kt
@@ -4,10 +4,30 @@
 
 package app.accrescent.server.parcelo.core
 
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class BytesTest {
+    @Test
+    fun `mutating the array passed to the constructor does not mutate the instance`() {
+        val byteArray = "deadbeef".hexToByteArray()
+        val bytes = Bytes(byteArray)
+
+        byteArray[0] = 0
+
+        assertArrayEquals("deadbeef".hexToByteArray(), bytes.copyToByteArray())
+    }
+
+    @Test
+    fun `mutating an array from copyToByteArray does not mutate the instance`() {
+        val bytes = Bytes("deadbeef".hexToByteArray())
+
+        bytes.copyToByteArray()[0] = 0
+
+        assertArrayEquals("deadbeef".hexToByteArray(), bytes.copyToByteArray())
+    }
+
     @Test
     fun `instances with same contents are equal`() {
         val instance1 = Bytes("deadbeef".hexToByteArray())

--- a/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/xml/XmlDocumentTest.kt
+++ b/parcelo/src/test/kotlin/app/accrescent/server/parcelo/domain/android/xml/XmlDocumentTest.kt
@@ -21,7 +21,7 @@ class XmlDocumentTest {
     @ParameterizedTest
     @MethodSource("fromBinaryXmlTestCases")
     fun `fromBinaryXml returns expected document`(testCase: FromBinaryXmlTestCase) {
-        val result = XmlDocument.fromBinaryXml(ByteBuffer.wrap(testCase.binaryXml.value)).unwrap()
+        val result = XmlDocument.fromBinaryXml(ByteBuffer.wrap(testCase.binaryXml.copyToByteArray())).unwrap()
 
         assertEquals(testCase.expectedDocument, result)
     }
@@ -37,7 +37,7 @@ class XmlDocumentTest {
         // `A: package="com.example.decoy" (Raw: "com.example.real")`.
         val binaryXml = binaryXmlTestData("mismatched-string-attribute-manifest.axml.gz")
 
-        val result = XmlDocument.fromBinaryXml(ByteBuffer.wrap(binaryXml.value))
+        val result = XmlDocument.fromBinaryXml(ByteBuffer.wrap(binaryXml.copyToByteArray()))
 
         assertTrue(result.isLeft())
     }


### PR DESCRIPTION
We've treated Bytes instances as de facto immutable, but this has not been enforced since their underlying mutable byte arrays are exposed outside of them. To prevent any future issues, perform defensive copies when converting to/from ByteArrays, making Bytes completely immutable.